### PR TITLE
Add type check ci

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         pip install --upgrade pip

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,0 +1,19 @@
+name: Type checks
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.10
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install mypy
+    - name: Check types with Mypy
+      run: mypy $(git ls-files '*.py') --install-types --non-interactive

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.10
+warn_return_any = True
+warn_unused_configs = True


### PR DESCRIPTION
做了 2 件事

1. 新增 mypy 的設定檔，其中只包含最基本的設定，其他需求可以在遇到時新增
2. 每次 push 和 PR 時都有 CI check 確定 type 標註的正確性。
往後引入分支策略時，可以考慮需不需要在 feature branch 上檢查，或是只在 `main` 和 `develop` 的 PR 檢查

註：這是個小新增，可以使用 `squash`