### PR TITLE
Replace absolute path & use built-in static file serving

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from secrets import token_hex
 from typing import Any, Mapping
 
-from flask import Flask, current_app, send_from_directory
+from flask import Flask, current_app
 
 from database.util import connect_database_for_app
 
@@ -17,7 +17,7 @@ def create_app(test_config: Mapping[str, Any] = None) -> Flask:
         __name__,
         instance_path=str(Path(__file__).parent / "instance"),
         instance_relative_config=True,
-        static_url_path="",
+        static_folder=(Path(__file__).parents[1] / "static"),
     )
     app.config.from_mapping(
         SECRET_KEY=token_hex(),
@@ -28,10 +28,6 @@ def create_app(test_config: Mapping[str, Any] = None) -> Flask:
         app.config.from_mapping(test_config)
 
     _create_path_if_not_exist(app.instance_path)
-
-    @app.route("/static/<path:path>", methods=["GET"])
-    def return_static_file(path):
-        return send_from_directory("../static", path)
 
     @app.route("/", methods=["GET"])
     def index():

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,14 +2,14 @@ from pathlib import Path
 from secrets import token_hex
 from typing import Any, Mapping
 
-from flask import Flask, send_from_directory
+from flask import Flask, current_app, send_from_directory
+
+from database.util import connect_database_for_app
 
 
 def fetch_page(page_name: str) -> str:
-    with open(f"/etc/fastshop/html/{page_name}.html") as page:
+    with current_app.open_resource(f"../html/{page_name}.html") as page:
         return page.read()
-
-from database.util import connect_database_for_app
 
 
 def create_app(test_config: Mapping[str, Any] = None) -> Flask:
@@ -31,7 +31,7 @@ def create_app(test_config: Mapping[str, Any] = None) -> Flask:
 
     @app.route("/static/<path:path>", methods=["GET"])
     def return_static_file(path):
-        return send_from_directory("/etc/fastshop/static", path)
+        return send_from_directory("../static", path)
 
     @app.route("/", methods=["GET"])
     def index():

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,7 @@ from database.util import connect_database_for_app
 
 
 def fetch_page(page_name: str) -> str:
-    with current_app.open_resource(f"../html/{page_name}.html") as page:
+    with current_app.open_resource(f"../html/{page_name}.html", mode="r") as page:
         return page.read()
 
 

--- a/backend/tests/test_factory.py
+++ b/backend/tests/test_factory.py
@@ -15,4 +15,4 @@ def test_config() -> None:
 
 def test_index(client: FlaskClient) -> None:
     response: TestResponse = client.get("/")
-    assert response.data == b"Hello World"
+    assert b"index.html (a marker for API test)" in response.data

--- a/backend/tests/test_static.py
+++ b/backend/tests/test_static.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app import fetch_page
+
+if TYPE_CHECKING:
+    from flask.testing import FlaskClient, TestResponse
+
+
+def test_fetch_page(client: FlaskClient) -> None:
+    with client.application.app_context():
+        page_content: str = fetch_page("index")
+
+    assert "index.html (a marker for API test)" in page_content
+
+
+def test_return_static_file(client: FlaskClient) -> None:
+    response: TestResponse = client.get("/static/js/index.js")
+
+    assert response.status_code == 200
+    # not asserting data here because the file content may change

--- a/html/index.html
+++ b/html/index.html
@@ -1,3 +1,4 @@
+<!-- index.html (a marker for API test) -->
 <html>
     <link rel="stylesheet" href="/static/css/output.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -5,7 +6,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Mochiy+Pop+One&family=Noto+Sans+TC:wght@700&display=swap" rel="stylesheet">
     <body>
         <div id="app"></div>
-    </body> 
+    </body>
     <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
     <script src="/static/js/index.js"></script>


### PR DESCRIPTION
# Changes

- 移除了對開發 / 架設環境的路徑依賴
- 使用 *Flask* 內建的 static file 服務 API 來取代自己寫的 API (`route` 不變)
- 新增與更新對 API 的單元測試

# Checks

- [x] 已通過單元測試

---

Resolved: #18 