### PR TITLE
Import TestResponse from Werkzeug instead of Flask

### DIFF
--- a/backend/tests/test_factory.py
+++ b/backend/tests/test_factory.py
@@ -7,7 +7,8 @@ import pytest
 from app import create_app
 
 if TYPE_CHECKING:
-    from flask.testing import FlaskClient, TestResponse
+    from flask.testing import FlaskClient
+    from werkzeug.test import TestResponse
 
 
 @pytest.mark.skip("Depends on running database.")


### PR DESCRIPTION
[TestResponse](https://werkzeug.palletsprojects.com/en/2.2.x/test/#werkzeug.test.TestResponse) is at Werkzeug, not Flask. Flask doesn't extend it.