### PR TITLE
Measure branch coverage

### DIFF
--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -4,3 +4,9 @@ omit = tests/*.py
 
 [report]
 show_missing = True
+exclude_lines =
+  # Re-enable the standard pragma
+  pragma: no cover
+
+  # Type checking only
+  if TYPE_CHECKING:

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,2 +1,3 @@
 [run]
+branch = True
 omit = tests/*.py

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,3 +1,6 @@
 [run]
 branch = True
 omit = tests/*.py
+
+[report]
+show_missing = True


### PR DESCRIPTION
對 *pytest-cov* 的組態新增了參數，只要下 `python -m pytest --cov` 就會額外顯示以下資訊：

- 未完全覆蓋的 branch（變得嚴格）：
這同時影響 *backend-unit-test* CI 中的覆蓋率報表，導致 merge 這個 PR 會降低整體覆蓋率，但實質上沒有 
- 未被覆蓋的 line number

同時讓 branch coverage 忽略 `if TYPE_CHECKING` 的 branch，因為這個條件只有在 type checking 的時候才會滿足，不是我們的測試在乎的事情。