### PR TITLE
Ignore .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PYTHONPATH=./backend

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ public
 # Control package versions with Dockerfile
 package-lock.json
 package.json
+
+.env


### PR DESCRIPTION
So that we don't share secret keys accidentally.
*.env* can be shared, but they should be shared more carefully.

> Note: I would like to have this small PR squashed.