### PR TITLE
提供 jwt_verify 接口以用於驗證 jwt 並回傳 jwt payload

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from secrets import token_hex
 from typing import Any, Mapping
 
 from flask import Flask
@@ -17,6 +18,8 @@ def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
         app.config.from_pyfile("config.py")
     else:
         app.config.from_mapping(test_config)
+    # a random key for jwt encoding
+    app.config["jwt_key"] = token_hex()
 
     db.init_app(app)
     app.cli.add_command(create_db_command)

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -9,7 +9,7 @@ from flask import Blueprint, Response, make_response, request
 from auth.exception import EmailAlreadyRegisteredError, IncorrectEmailOrPasswordError
 from auth.util import (
     BIRTHDAY_FORMAT,
-    JWTCodec,
+    HS256JWTCodec,
     UserProfile,
     fetch_user_profile,
     is_valid_birthday,
@@ -116,7 +116,7 @@ def verify_jwt_route() -> Response:
         return _make_single_message_response(HTTPStatus.UNAUTHORIZED, ABSENT_COOKIE)
 
     jwt_token: str = request.cookies["jwt"]
-    jwt_codec = JWTCodec()
+    jwt_codec = HS256JWTCodec()
 
     if not jwt_codec.is_valid_jwt(jwt_token):
         return _make_single_message_response(
@@ -149,7 +149,7 @@ def _set_jwt_cookie_to_response(
     response: Response,
     expiration_time_delta: timedelta = timedelta(days=1),
 ) -> None:
-    codec = JWTCodec()
+    codec = HS256JWTCodec()
     token: str = codec.encode(payload, expiration_time_delta)
     response.set_cookie(
         "jwt",

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -116,7 +116,7 @@ def verify_jwt_route() -> Response:
     if "jwt" not in request.cookies:
         return _make_single_message_response(HTTPStatus.UNAUTHORIZED, ABSENT_COOKIE)
 
-    jwt_token = request.cookies.get("jwt")
+    jwt_token = request.cookies["jwt"]
     jwt_codec = JWTCodec()
 
     if not jwt_codec.is_valid_jwt(jwt_token):

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
 
-from flask import Blueprint, Response, make_response, request
+from flask import Blueprint, Response, current_app, make_response, request
 
 from auth.exception import EmailAlreadyRegisteredError, IncorrectEmailOrPasswordError
 from auth.util import (
@@ -116,7 +116,7 @@ def verify_jwt_route() -> Response:
         return _make_single_message_response(HTTPStatus.UNAUTHORIZED, ABSENT_COOKIE)
 
     jwt_token: str = request.cookies["jwt"]
-    jwt_codec = HS256JWTCodec()
+    jwt_codec = HS256JWTCodec(current_app.config["jwt_key"])
 
     if not jwt_codec.is_valid_jwt(jwt_token):
         return _make_single_message_response(
@@ -149,7 +149,7 @@ def _set_jwt_cookie_to_response(
     response: Response,
     expiration_time_delta: timedelta = timedelta(days=1),
 ) -> None:
-    codec = HS256JWTCodec()
+    codec = HS256JWTCodec(current_app.config["jwt_key"])
     token: str = codec.encode(payload, expiration_time_delta)
     response.set_cookie(
         "jwt",

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -120,7 +120,9 @@ def verify_jwt_route() -> Response:
     jwt_codec = JWTCodec()
 
     if not jwt_codec.is_valid_jwt(jwt_token):
-        return _make_single_message_response(HTTPStatus.UNAUTHORIZED, INVALID_COOKIE)
+        return _make_single_message_response(
+            HTTPStatus.UNPROCESSABLE_ENTITY, INVALID_COOKIE
+        )
 
     jwt_payload = jwt_codec.decode(jwt_token)
     json_jwt_payload = json.dumps(jwt_payload)

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import json
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
 
-from flask import Blueprint, make_response, request, Response
+from flask import Blueprint, Response, make_response, request
 
 from auth.exception import EmailAlreadyRegisteredError, IncorrectEmailOrPasswordError
 from auth.util import (
@@ -116,7 +115,7 @@ def verify_jwt_route() -> Response:
     if "jwt" not in request.cookies:
         return _make_single_message_response(HTTPStatus.UNAUTHORIZED, ABSENT_COOKIE)
 
-    jwt_token = request.cookies["jwt"]
+    jwt_token: str = request.cookies["jwt"]
     jwt_codec = JWTCodec()
 
     if not jwt_codec.is_valid_jwt(jwt_token):
@@ -124,10 +123,8 @@ def verify_jwt_route() -> Response:
             HTTPStatus.UNPROCESSABLE_ENTITY, INVALID_COOKIE
         )
 
-    jwt_payload = jwt_codec.decode(jwt_token)
-    json_jwt_payload = json.dumps(jwt_payload)
-
-    return Response(json_jwt_payload, status=HTTPStatus.OK, mimetype="application/json")
+    jwt_payload: dict[str, Any] = jwt_codec.decode(jwt_token)
+    return make_response(jwt_payload)
 
 
 def _has_required_login_data(data: Mapping[str, Any]) -> bool:

--- a/backend/auth/util.py
+++ b/backend/auth/util.py
@@ -66,10 +66,10 @@ class UserProfile:
     birthday: int
 
 
-class JWTCodec:
-    def __init__(self, key: str = "secret", algorithm: str = "HS256") -> None:
-        self._key: str = key
-        self._algorithm: str = algorithm
+class HS256JWTCodec:
+    def __init__(self) -> None:
+        self._key: Final[str] = "secret"
+        self._algorithm: Final[str] = "HS256"
 
     @property
     def key(self) -> str:

--- a/backend/auth/util.py
+++ b/backend/auth/util.py
@@ -67,8 +67,8 @@ class UserProfile:
 
 
 class HS256JWTCodec:
-    def __init__(self) -> None:
-        self._key: Final[str] = "secret"
+    def __init__(self, key: str) -> None:
+        self._key: Final[str] = key
         self._algorithm: Final[str] = "HS256"
 
     @property

--- a/backend/response_message.py
+++ b/backend/response_message.py
@@ -1,8 +1,8 @@
-ABSENT_COOKIE = "The specific cookie does not exist in request header."
+ABSENT_COOKIE = "The specific cookie does not exist in the request header."
 DUPLICATE_ACCOUNT = "The posted email already exist."
 INCORRECT_EMAIL_OR_PASSWORD = (
     "The email or password that the user posted does not match any account."
 )
-INVALID_COOKIE = "The specific cookie in request header is invalid."
+INVALID_COOKIE = "The specific cookie in the request header is invalid."
 INVALID_DATA = "The posted data has the correct format, but the data is invalid."
 WRONG_DATA_FORMAT = "The data has the wrong format and the server can't understand it."

--- a/backend/response_message.py
+++ b/backend/response_message.py
@@ -1,4 +1,8 @@
+ABSENT_COOKIE = "The specific cookie does not exist in request header."
 DUPLICATE_ACCOUNT = "The posted email already exist."
-INCORRECT_EMAIL_OR_PASSWORD = "The email or password that the user posted does not match any account."
+INCORRECT_EMAIL_OR_PASSWORD = (
+    "The email or password that the user posted does not match any account."
+)
+INVALID_COOKIE = "The specific cookie in request header is invalid."
 INVALID_DATA = "The posted data has the correct format, but the data is invalid."
 WRONG_DATA_FORMAT = "The data has the wrong format and the server can't understand it."

--- a/backend/tests/integration_tests/test_auth.py
+++ b/backend/tests/integration_tests/test_auth.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from auth.util import Gender, JWTCodec
+from auth.util import Gender, HS256JWTCodec
 from database import db
 from models import User
 from tests.util import assert_not_raise
@@ -234,7 +234,7 @@ class TestLoginRoute:
         client: FlaskClient,
         new_data: dict[str, Any],
     ) -> None:
-        codec = JWTCodec()
+        codec = HS256JWTCodec()
 
         client.post("/login", json=new_data)
 

--- a/backend/tests/integration_tests/test_auth.py
+++ b/backend/tests/integration_tests/test_auth.py
@@ -12,6 +12,7 @@ from models import User
 from tests.util import assert_not_raise
 
 if TYPE_CHECKING:
+    from flask import Flask
     from flask.testing import FlaskClient
     from sqlalchemy.engine.row import Row
     from sqlalchemy.sql.selectable import Select
@@ -231,10 +232,11 @@ class TestLoginRoute:
 
     def test_post_with_correct_data_should_have_correct_jwt_token_attribute(
         self,
+        app: Flask,
         client: FlaskClient,
         new_data: dict[str, Any],
     ) -> None:
-        codec = HS256JWTCodec()
+        codec = HS256JWTCodec(app.config["jwt_key"])
 
         client.post("/login", json=new_data)
 

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from http import HTTPStatus
 from http.cookiejar import Cookie, CookieJar
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -286,12 +286,13 @@ class TestJWTVerify:
         resp: TestResponse = client.post("/verify_jwt")
 
         assert resp.is_json
-        assert resp.json["data"]["e-mail"] == payload_data["e-mail"]  # type: ignore
-        assert resp.json["data"]["password"] == payload_data["password"]  # type: ignore
-        assert resp.json["data"]["firstname"] == payload_data["firstname"]  # type: ignore
-        assert resp.json["data"]["lastname"] == payload_data["lastname"]  # type: ignore
-        assert resp.json["data"]["gender"] == payload_data["gender"]  # type: ignore
-        assert resp.json["data"]["birthday"] == payload_data["birthday"]  # type: ignore
+        payload_from_decoded_jwt_token: dict[str, str] = cast(dict[str, str], resp.json)
+        assert payload_from_decoded_jwt_token["e-mail"] == payload_data["e-mail"]
+        assert payload_from_decoded_jwt_token["password"] == payload_data["password"]
+        assert payload_from_decoded_jwt_token["firstname"] == payload_data["firstname"]
+        assert payload_from_decoded_jwt_token["lastname"] == payload_data["lastname"]
+        assert payload_from_decoded_jwt_token["gender"] == payload_data["gender"]
+        assert payload_from_decoded_jwt_token["birthday"] == payload_data["birthday"]
 
     def test_post_with_absent_jwt_cookie_should_have_code_http_unauthorized(
         self,
@@ -310,8 +311,9 @@ class TestJWTVerify:
         resp: TestResponse = client.post("/verify_jwt")
 
         assert resp.is_json
+        payload_from_decoded_jwt_token: dict[str, str] = cast(dict[str, str], resp.json)
         assert (
-            resp.json["message"]  # type: ignore
+            payload_from_decoded_jwt_token["message"]
             == "The specific cookie does not exist in request header."
         )
 

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
 from http import HTTPStatus
 from http.cookiejar import Cookie, CookieJar
 from typing import TYPE_CHECKING, Any
@@ -10,6 +9,7 @@ import pytest
 from auth.util import Gender, JWTCodec
 from database import db
 from models import User
+from tests.util import assert_not_raise
 
 if TYPE_CHECKING:
     from flask.testing import FlaskClient
@@ -226,7 +226,7 @@ class TestLoginRoute:
         client.post("/login", json=new_data)
 
         cookies: tuple[Cookie, ...] = _get_cookies(client.cookie_jar)
-        with _assert_not_raise(ValueError):
+        with assert_not_raise(ValueError):
             (jwt_cookie,) = tuple(filter(lambda x: x.name == "jwt", cookies))
 
     def test_post_with_correct_data_should_have_correct_jwt_token_attribute(
@@ -335,11 +335,3 @@ def _get_cookies(cookie_jar: CookieJar | None) -> tuple[Cookie, ...]:
     if cookie_jar is None:
         return tuple()
     return tuple(cookie for cookie in cookie_jar)
-
-
-@contextmanager
-def _assert_not_raise(exception):
-    try:
-        yield
-    except exception:
-        pytest.fail(f"DID RAISE {exception}")

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -286,12 +286,12 @@ class TestJWTVerify:
         resp: TestResponse = client.post("/verify_jwt")
 
         assert resp.is_json
-        assert resp.json["data"]["e-mail"] == payload_data["e-mail"]
-        assert resp.json["data"]["password"] == payload_data["password"]
-        assert resp.json["data"]["firstname"] == payload_data["firstname"]
-        assert resp.json["data"]["lastname"] == payload_data["lastname"]
-        assert resp.json["data"]["gender"] == payload_data["gender"]
-        assert resp.json["data"]["birthday"] == payload_data["birthday"]
+        assert resp.json["data"]["e-mail"] == payload_data["e-mail"]  # type: ignore
+        assert resp.json["data"]["password"] == payload_data["password"]  # type: ignore
+        assert resp.json["data"]["firstname"] == payload_data["firstname"]  # type: ignore
+        assert resp.json["data"]["lastname"] == payload_data["lastname"]  # type: ignore
+        assert resp.json["data"]["gender"] == payload_data["gender"]  # type: ignore
+        assert resp.json["data"]["birthday"] == payload_data["birthday"]  # type: ignore
 
     def test_post_with_absent_jwt_cookie_should_have_code_http_unauthorized(
         self,
@@ -311,7 +311,7 @@ class TestJWTVerify:
 
         assert resp.is_json
         assert (
-            resp.json["message"]
+            resp.json["message"]  # type: ignore
             == "The specific cookie does not exist in request header."
         )
 
@@ -335,7 +335,7 @@ class TestJWTVerify:
 
         assert resp.is_json
         assert (
-            resp.json["message"] == "The specific cookie in request header is invalid."
+            resp.json["message"] == "The specific cookie in request header is invalid."  # type: ignore
         )
 
 

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -303,7 +303,7 @@ class TestVerifyJWT:
         assert resp.is_json
         assert (
             resp.json["message"]  # type: ignore
-            == "The specific cookie does not exist in request header."
+            == "The specific cookie does not exist in the request header."
         )
 
     def test_post_with_invalid_jwt_cookie_should_have_code_http_unprocessable_entity(
@@ -327,7 +327,7 @@ class TestVerifyJWT:
         assert resp.is_json
         assert (
             resp.json["message"]  # type: ignore
-            == "The specific cookie in request header is invalid."
+            == "The specific cookie in the request header is invalid."
         )
 
 

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -12,6 +12,7 @@ from models import User
 from tests.util import assert_not_raise
 
 if TYPE_CHECKING:
+    from flask import Flask
     from flask.testing import FlaskClient
     from sqlalchemy.engine.row import Row
     from sqlalchemy.sql.selectable import Select
@@ -231,10 +232,11 @@ class TestLoginRoute:
 
     def test_post_with_correct_data_should_have_correct_jwt_token_attribute(
         self,
+        app: Flask,
         client: FlaskClient,
         new_data: dict[str, Any],
     ) -> None:
-        codec = HS256JWTCodec()
+        codec = HS256JWTCodec(app.config["jwt_key"])
 
         client.post("/login", json=new_data)
 
@@ -263,10 +265,11 @@ class TestVerifyJWT:
 
     def test_post_with_valid_jwt_cookie_should_have_code_http_ok(
         self,
+        app: Flask,
         client: FlaskClient,
         payload: dict[str, Any],
     ) -> None:
-        jwt_token: str = HS256JWTCodec().encode(payload)
+        jwt_token: str = HS256JWTCodec(app.config["jwt_key"]).encode(payload)
         client.set_cookie("localhost", "jwt", jwt_token)
 
         resp: TestResponse = client.post("/verify_jwt")
@@ -275,10 +278,11 @@ class TestVerifyJWT:
 
     def test_post_with_valid_jwt_cookie_should_return_payload_in_json(
         self,
+        app: Flask,
         client: FlaskClient,
         payload: dict[str, Any],
     ) -> None:
-        jwt_token: str = HS256JWTCodec().encode(payload)
+        jwt_token: str = HS256JWTCodec(app.config["jwt_key"]).encode(payload)
         client.set_cookie("localhost", "jwt", jwt_token)
 
         resp: TestResponse = client.post("/verify_jwt")

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -286,7 +286,7 @@ class TestJWTVerify:
         resp: TestResponse = client.post("/verify_jwt")
 
         assert resp.is_json
-        respones_payload: dict[str, str] = cast(dict[str, str], resp.json)
+        respones_payload: dict[str, Any] = cast(dict[str, Any], resp.json)
         assert respones_payload["data"]["e-mail"] == payload_data["e-mail"]
         assert respones_payload["data"]["password"] == payload_data["password"]
         assert respones_payload["data"]["firstname"] == payload_data["firstname"]

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -286,13 +286,13 @@ class TestJWTVerify:
         resp: TestResponse = client.post("/verify_jwt")
 
         assert resp.is_json
-        payload_from_decoded_jwt_token: dict[str, str] = cast(dict[str, str], resp.json)
-        assert payload_from_decoded_jwt_token["e-mail"] == payload_data["e-mail"]
-        assert payload_from_decoded_jwt_token["password"] == payload_data["password"]
-        assert payload_from_decoded_jwt_token["firstname"] == payload_data["firstname"]
-        assert payload_from_decoded_jwt_token["lastname"] == payload_data["lastname"]
-        assert payload_from_decoded_jwt_token["gender"] == payload_data["gender"]
-        assert payload_from_decoded_jwt_token["birthday"] == payload_data["birthday"]
+        respones_payload: dict[str, str] = cast(dict[str, str], resp.json)
+        assert respones_payload["data"]["e-mail"] == payload_data["e-mail"]
+        assert respones_payload["data"]["password"] == payload_data["password"]
+        assert respones_payload["data"]["firstname"] == payload_data["firstname"]
+        assert respones_payload["data"]["lastname"] == payload_data["lastname"]
+        assert respones_payload["data"]["gender"] == payload_data["gender"]
+        assert respones_payload["data"]["birthday"] == payload_data["birthday"]
 
     def test_post_with_absent_jwt_cookie_should_have_code_http_unauthorized(
         self,

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -315,7 +315,7 @@ class TestJWTVerify:
             == "The specific cookie does not exist in request header."
         )
 
-    def test_post_with_invalid_jwt_cookie_should_have_code_http_unauthorized(
+    def test_post_with_invalid_jwt_cookie_should_have_code_http_unprocessable_entity(
         self,
         client: FlaskClient,
     ) -> None:
@@ -323,7 +323,7 @@ class TestJWTVerify:
         client.set_cookie("localhost", "jwt", "aaa.bbb.ccc")
         resp: TestResponse = client.post("/verify_jwt")
 
-        assert resp.status_code == HTTPStatus.UNAUTHORIZED
+        assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
     def test_post_with_invalid_jwt_cookie_should_return_failed_message_in_json(
         self,

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from auth.util import Gender, JWTCodec
+from auth.util import Gender, HS256JWTCodec
 from database import db
 from models import User
 from tests.util import assert_not_raise
@@ -234,7 +234,7 @@ class TestLoginRoute:
         client: FlaskClient,
         new_data: dict[str, Any],
     ) -> None:
-        codec = JWTCodec()
+        codec = HS256JWTCodec()
 
         client.post("/login", json=new_data)
 
@@ -266,7 +266,7 @@ class TestVerifyJWT:
         client: FlaskClient,
         payload: dict[str, Any],
     ) -> None:
-        jwt_token: str = JWTCodec().encode(payload)
+        jwt_token: str = HS256JWTCodec().encode(payload)
         client.set_cookie("localhost", "jwt", jwt_token)
 
         resp: TestResponse = client.post("/verify_jwt")
@@ -278,7 +278,7 @@ class TestVerifyJWT:
         client: FlaskClient,
         payload: dict[str, Any],
     ) -> None:
-        jwt_token: str = JWTCodec().encode(payload)
+        jwt_token: str = HS256JWTCodec().encode(payload)
         client.set_cookie("localhost", "jwt", jwt_token)
 
         resp: TestResponse = client.post("/verify_jwt")

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -274,7 +274,7 @@ class TestJWTVerify:
 
         assert resp.status_code == HTTPStatus.OK
 
-    def test_post_with_valid_jwt_cookie_should_return_jwt_payload_in_json(
+    def test_post_with_valid_jwt_cookie_should_return_payload_data_in_json(
         self,
         client: FlaskClient,
         payload_data: dict[str, Any],

--- a/backend/tests/unit_tests/test_auth_util.py
+++ b/backend/tests/unit_tests/test_auth_util.py
@@ -14,7 +14,7 @@ from auth.exception import (
 )
 from auth.util import (
     Gender,
-    JWTCodec,
+    HS256JWTCodec,
     UserProfile,
     fetch_user_profile,
     is_correct_password,
@@ -199,13 +199,13 @@ class TestFetchUserProfile:
                 fetch_user_profile(unregister_email)
 
 
-class TestJWTCodec:
+class TestHS256JWTCodec:
     @pytest.fixture
-    def codec(self) -> JWTCodec:
-        return JWTCodec(key="secret", algorithm="HS256")
+    def codec(self) -> HS256JWTCodec:
+        return HS256JWTCodec()
 
     @freezegun.freeze_time("2000-01-01 00:00:00")
-    def test_encode(self, codec: JWTCodec) -> None:
+    def test_encode(self, codec: HS256JWTCodec) -> None:
         data: dict[str, str] = {"some": "payload"}
 
         token: str = codec.encode(data, timedelta(days=1))
@@ -213,7 +213,7 @@ class TestJWTCodec:
         expected: str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjp7InNvbWUiOiJwYXlsb2FkIn0sImlhdCI6OTQ2Njg0ODAwLCJleHAiOjk0Njc3MTIwMH0.FU7fNuSrA-EuVtpE2duW-VD9hJX1B1QfPuQ2_kJ95Lw"
         assert token == expected
 
-    def test_decode(self, codec: JWTCodec) -> None:
+    def test_decode(self, codec: HS256JWTCodec) -> None:
         token: str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg"
 
         data: dict = codec.decode(token)
@@ -224,25 +224,29 @@ class TestJWTCodec:
     class TestIsValidJWT:
         def test_on_token_with_not_enough_segment_should_return_false(
             self,
-            codec: JWTCodec,
+            codec: HS256JWTCodec,
         ) -> None:
             token: str = "should_have_three_dot_separated_segments"
 
             assert not codec.is_valid_jwt(token)
 
-        def test_on_invalid_token_should_return_false(self, codec: JWTCodec) -> None:
+        def test_on_invalid_token_should_return_false(
+            self, codec: HS256JWTCodec
+        ) -> None:
             token: str = "this.failed.validation"
 
             assert not codec.is_valid_jwt(token)
 
-        def test_on_expired_token_should_return_false(self, codec: JWTCodec) -> None:
+        def test_on_expired_token_should_return_false(
+            self, codec: HS256JWTCodec
+        ) -> None:
             time_to_the_past = timedelta(days=-87)
 
             token: str = codec.encode({"some": "payload"}, time_to_the_past)
 
             assert not codec.is_valid_jwt(token)
 
-        def test_on_vaild_token_should_return_true(self, codec: JWTCodec) -> None:
+        def test_on_vaild_token_should_return_true(self, codec: HS256JWTCodec) -> None:
             payload: dict[str, str] = {"some": "payload"}
             token: str = jwt.encode(payload, key=codec.key, algorithm=codec.algorithm)
 

--- a/backend/tests/unit_tests/test_auth_util.py
+++ b/backend/tests/unit_tests/test_auth_util.py
@@ -201,7 +201,7 @@ class TestFetchUserProfile:
 
 class TestHS256JWTCodec:
     @pytest.fixture
-    def codec(self, app: Flask) -> HS256JWTCodec:
+    def codec(self) -> HS256JWTCodec:
         return HS256JWTCodec("secret")
 
     @freezegun.freeze_time("2000-01-01 00:00:00")

--- a/backend/tests/unit_tests/test_auth_util.py
+++ b/backend/tests/unit_tests/test_auth_util.py
@@ -201,8 +201,8 @@ class TestFetchUserProfile:
 
 class TestHS256JWTCodec:
     @pytest.fixture
-    def codec(self) -> HS256JWTCodec:
-        return HS256JWTCodec()
+    def codec(self, app: Flask) -> HS256JWTCodec:
+        return HS256JWTCodec("secret")
 
     @freezegun.freeze_time("2000-01-01 00:00:00")
     def test_encode(self, codec: HS256JWTCodec) -> None:


### PR DESCRIPTION
在這次的變更，我們提供了一個 `/jwt_verify` 的接口，API 描述如下：

```
POST /verify_jwt

Required: [none]
Data Parameter: [none]
Success Response:
    - code: 200
        - content: JSON object
            - iat: When the jwt token is generated.
            - exp: When the jwt token expired.
            - data: The encoded data in jwt payload.
                - e-mail: The e-mail in jwt encoded data. [str]
                - firstname: The first name in jwt encode data. [str]
                - lastname: The lastname in jwt encode data. [str]
                - gender: The gender in jwt encoded data. [0-1]
                - birthday: The birthday in jwt encode data. [yyyy-mm-dd]
Error Response:
  - code: 401
    - content:
      - message: The specific cookie does not exist in the request header.
  - code: 422
    - content:
      - message: The specific cookie in the request header is invalid.
```

並且在 `test_auth.py` 新增了六個測試
 - `TestJWTVerify::test_post_with_valid_jwt_cookie_should_have_code_http_ok`
 - `TestJWTVerify::test_post_with_valid_jwt_cookie_should_return_payload_data_in_json`
 - `TestJWTVerify::test_post_with_absent_jwt_cookie_should_have_code_http_unauthorized`
 - `TestJWTVerify::test_post_with_absent_jwt_cookie_should_return_failed_message_in_json`
 - `TestJWTVerify::test_post_with_invalid_jwt_cookie_should_have_code_http_unprocessable_entity`
 - `TestJWTVerify::test_post_with_invalid_jwt_cookie_should_return_failed_message_in_json`

Resolve: #57 