### PR TITLE
Fix data not store in the database

### DIFF
--- a/backend/auth/util.py
+++ b/backend/auth/util.py
@@ -128,6 +128,7 @@ def register(email: str, password: str, profile: UserProfile) -> None:
         birthday=profile.birthday,
     )
     db.session.execute(insert_new_user_stmt)
+    db.session.commit()
 
 
 def is_correct_password(registered_email: str, password_to_check: str) -> bool:

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -52,6 +52,7 @@ class TestRegisterRoute:
 
             client.post("/register", json=new_data)
 
+        with client.application.app_context():
             stmt: Select = db.select(User.firstname, User.lastname, User.gender).where(
                 User.email == "new@gmail.com"
             )


### PR DESCRIPTION
`commit` is missing in the `register` function, which makes the response OK (200), but the user data is not stored in the database.

Also, the current test case checks whether the user data is stored in the database or not in the same request as registration, which makes the test pass since the database does not roll back until the request ends.

Resolves: #59 