### PR TITLE
完成登出接口的實作

### DIFF
--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -127,6 +127,13 @@ def verify_jwt_route() -> Response:
     return make_response(jwt_payload)
 
 
+@auth_bp.route("/logout", methods=["POST"])
+def logout_route() -> Response:
+    response: Response = _make_single_message_response(HTTPStatus.OK)
+    _delete_jwt_cookie_from_response(response)
+    return response
+
+
 def _has_required_login_data(data: Mapping[str, Any]) -> bool:
     return "e-mail" in data and "password" in data
 
@@ -156,3 +163,9 @@ def _set_jwt_cookie_to_response(
         value=token,
         expires=datetime.now(tz=timezone.utc) + expiration_time_delta,
     )
+
+
+def _delete_jwt_cookie_from_response(
+    response: Response,
+):
+    response.delete_cookie("jwt")

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -130,7 +130,7 @@ def verify_jwt_route() -> Response:
 @auth_bp.route("/logout", methods=["POST"])
 def logout_route() -> Response:
     response: Response = _make_single_message_response(HTTPStatus.OK)
-    _delete_jwt_cookie_from_response(response)
+    response.delete_cookie("jwt")
     return response
 
 
@@ -163,9 +163,3 @@ def _set_jwt_cookie_to_response(
         value=token,
         expires=datetime.now(tz=timezone.utc) + expiration_time_delta,
     )
-
-
-def _delete_jwt_cookie_from_response(
-    response: Response,
-):
-    response.delete_cookie("jwt")

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -336,6 +336,37 @@ class TestVerifyJWT:
         )
 
 
+class TestLogout:
+    def test_if_jwt_exist_logout_should_return_ok(
+        self,
+        client: FlaskClient,
+    ) -> None:
+        client.set_cookie("localhost", "jwt", "aaa.bbb.ccc")
+
+        resp: TestResponse = client.post("/logout")
+
+        assert resp.status_code == HTTPStatus.OK
+
+    def test_if_jwt_exist_logout_should_let_jwt_token_absent(
+        self,
+        client: FlaskClient,
+    ) -> None:
+        client.set_cookie("localhost", "jwt", "aaa.bbb.ccc")
+
+        client.post("/logout")
+        cookies: tuple[Cookie, ...] = _get_cookies(client.cookie_jar)
+
+        assert len(cookies) == 0
+
+    def test_if_jwt_absent_logout_should_return_ok(
+        self,
+        client: FlaskClient,
+    ) -> None:
+        resp: TestResponse = client.post("/logout")
+
+        assert resp.status_code == HTTPStatus.OK
+
+
 def _get_cookies(cookie_jar: CookieJar | None) -> tuple[Cookie, ...]:
     if cookie_jar is None:
         return tuple()

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -354,8 +354,8 @@ class TestLogout:
         client.set_cookie("localhost", "jwt", "aaa.bbb.ccc")
 
         client.post("/logout")
-        cookies: tuple[Cookie, ...] = _get_cookies(client.cookie_jar)
 
+        cookies: tuple[Cookie, ...] = _get_cookies(client.cookie_jar)
         assert len(cookies) == 0
 
     def test_if_jwt_absent_should_return_ok(

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -356,7 +356,7 @@ class TestLogout:
         client.post("/logout")
 
         cookies: tuple[Cookie, ...] = _get_cookies(client.cookie_jar)
-        assert len(cookies) == 0
+        assert not cookies
 
     def test_if_jwt_absent_should_return_ok(
         self,

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -337,7 +337,7 @@ class TestVerifyJWT:
 
 
 class TestLogout:
-    def test_if_jwt_exist_logout_should_return_ok(
+    def test_if_jwt_exist_should_return_ok(
         self,
         client: FlaskClient,
     ) -> None:
@@ -347,7 +347,7 @@ class TestLogout:
 
         assert resp.status_code == HTTPStatus.OK
 
-    def test_if_jwt_exist_logout_should_let_jwt_token_absent(
+    def test_if_jwt_exist_should_let_jwt_token_absent(
         self,
         client: FlaskClient,
     ) -> None:
@@ -358,7 +358,7 @@ class TestLogout:
 
         assert len(cookies) == 0
 
-    def test_if_jwt_absent_logout_should_return_ok(
+    def test_if_jwt_absent_should_return_ok(
         self,
         client: FlaskClient,
     ) -> None:


### PR DESCRIPTION
在這個 PR 中，我們完成了後端的登出接口實作。

### 預期功能

我們預期在後端的登出接口功能，在使用者對 `logout` 接口進行 POST 查詢時，會註銷使用者的 `jwt` cookie。

### 測試

我們撰寫了三個測試，分別是：

 - `test_if_jwt_exist_logout_should_return_ok`：當 `jwt` cookie 存在時，使用 `logout` 接口應回傳 HTTP Status Code `OK`。
 - `test_if_jwt_exist_logout_should_let_jwt_token_absent`：當 `jwt` cookie 存在時，使用 `logout` 接口應使 `jwt` cookie 消失。
 - `test_if_jwt_absent_logout_should_return_ok`：當 `jwt` cookie 不存在時，使用 `logout` 接口應回傳 HTTP Status Code `OK`。

