### PR TITLE
將只檢查信箱密碼是否正確的 `login` 的 util 函式改為 bool 查詢函式

### DIFF
--- a/backend/auth/exception.py
+++ b/backend/auth/exception.py
@@ -1,7 +1,3 @@
-class IncorrectEmailOrPasswordError(RuntimeError):
-    pass
-
-
 class EmailAlreadyRegisteredError(RuntimeError):
     pass
 

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -48,7 +48,7 @@ def login_route() -> Response | str:
                 HTTPStatus.UNPROCESSABLE_ENTITY, message=INVALID_DATA
             )
 
-        if not _has_correct_email_and_password(data["e-mail"], data["password"]):
+        if not _is_correct_email_and_password(data["e-mail"], data["password"]):
             return _make_single_message_response(
                 HTTPStatus.FORBIDDEN, message=INCORRECT_EMAIL_OR_PASSWORD
             )
@@ -128,7 +128,7 @@ def verify_jwt_route() -> Response:
     return make_response(jwt_payload)
 
 
-def _has_correct_email_and_password(email: str, password: str) -> bool:
+def _is_correct_email_and_password(email: str, password: str) -> bool:
     return is_registered(email) and is_correct_password(email, password)
 
 

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -6,15 +6,16 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
 
 from flask import Blueprint, Response, current_app, make_response, request
 
-from auth.exception import EmailAlreadyRegisteredError, IncorrectEmailOrPasswordError
+from auth.exception import EmailAlreadyRegisteredError
 from auth.util import (
     BIRTHDAY_FORMAT,
     HS256JWTCodec,
     UserProfile,
     fetch_user_profile,
+    is_correct_password,
+    is_registered,
     is_valid_birthday,
     is_valid_email,
-    login,
     register,
 )
 from response_message import (
@@ -47,18 +48,18 @@ def login_route() -> Response | str:
                 HTTPStatus.UNPROCESSABLE_ENTITY, message=INVALID_DATA
             )
 
-        try:
-            login(data["e-mail"], data["password"])
-        except IncorrectEmailOrPasswordError:
+        if not _has_correct_email_and_password(data["e-mail"], data["password"]):
             return _make_single_message_response(
                 HTTPStatus.FORBIDDEN, message=INCORRECT_EMAIL_OR_PASSWORD
             )
         else:
             response: Response = _make_single_message_response(HTTPStatus.OK)
 
-            del data["password"]
-            data |= fetch_user_profile(data["e-mail"])
-            _set_jwt_cookie_to_response(data, response)
+            # Not using `del data["password"] because there might be something
+            # other then e-mail and password in the posted data`.
+            payload: dict[str, Any] = {"e-mail": data["e-mail"]}
+            payload |= fetch_user_profile(data["e-mail"])
+            _set_jwt_cookie_to_response(payload, response)
 
             return response
 
@@ -127,8 +128,8 @@ def verify_jwt_route() -> Response:
     return make_response(jwt_payload)
 
 
-def _has_required_login_data(data: Mapping[str, Any]) -> bool:
-    return "e-mail" in data and "password" in data
+def _has_correct_email_and_password(email: str, password: str) -> bool:
+    return is_registered(email) and is_correct_password(email, password)
 
 
 def _has_required_columns(data: Mapping, required_columns: Iterable) -> bool:

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -38,7 +38,7 @@ def login_route() -> Response | str:
     if request.method == "POST":
         data = request.json
 
-        if data is None or not _has_required_login_data(data):
+        if data is None or "e-mail" not in data or "password" not in data:
             return _make_single_message_response(
                 HTTPStatus.BAD_REQUEST, message=WRONG_DATA_FORMAT
             )

--- a/backend/auth/util.py
+++ b/backend/auth/util.py
@@ -10,7 +10,6 @@ from sqlalchemy import select
 
 from auth.exception import (
     EmailAlreadyRegisteredError,
-    IncorrectEmailOrPasswordError,
     UserNotFoundError,
 )
 from database import db
@@ -40,16 +39,6 @@ def is_valid_birthday(birthday: str) -> bool:
     except ValueError:
         return False
     return True
-
-
-def login(email: str, password: str) -> None:
-    """
-    Raises:
-        IncorrectEmailOrPasswordError
-    """
-    if not is_registered(email) or not is_correct_password(email, password):
-        raise IncorrectEmailOrPasswordError
-    # TODO: modify some cookie to mark the user as logged in
 
 
 @dataclass

--- a/backend/tests/unit_tests/test_auth_util.py
+++ b/backend/tests/unit_tests/test_auth_util.py
@@ -9,7 +9,6 @@ import pytest
 
 from auth.exception import (
     EmailAlreadyRegisteredError,
-    IncorrectEmailOrPasswordError,
     UserNotFoundError,
 )
 from auth.util import (
@@ -21,7 +20,6 @@ from auth.util import (
     is_registered,
     is_valid_birthday,
     is_valid_email,
-    login,
     register,
 )
 from database import db
@@ -138,24 +136,6 @@ class TestIsRegistered:
         with app.app_context():
 
             assert not is_registered(unregistered_email)
-
-
-class TestLogin:
-    def test_on_unregistered_email_should_raise_exception(self, app: Flask) -> None:
-        unregistered_email: str = "unregistered@email.com"
-        password: str = "test"
-        with app.app_context():
-
-            with pytest.raises(IncorrectEmailOrPasswordError):
-                login(unregistered_email, password)
-
-    def test_on_incorrect_password_should_raise_exception(self, app: Flask) -> None:
-        email: str = "test@email.com"
-        incorrect_password: str = "should_be_test"
-        with app.app_context():
-
-            with pytest.raises(IncorrectEmailOrPasswordError):
-                login(email, incorrect_password)
 
 
 class TestRegister:


### PR DESCRIPTION
在 #63 中，我們希望能將設定 jwt 的工作移到 `login` 這個 util 函式中，但

- 設定 jwt 需要先有 response，如此我們需要在 `login` 這個 util 函式中產生 response，這樣太多了。

產生 response 應要是 route 的工作，所以我並未調整工作分擔，而是將原先的 `login` 改成名為 `is_correct_email_and_password` 的 bool 查詢函式來吻合它實際上做的事情。

Closed: #63 