### PR TITLE
Add integration tests of logout route

### DIFF
--- a/backend/tests/integration_tests/test_auth.py
+++ b/backend/tests/integration_tests/test_auth.py
@@ -1,7 +1,11 @@
-from tests.unit_tests.test_auth import TestLoginRoute, TestRegisterRoute
+from tests.unit_tests.test_auth import TestLoginRoute, TestLogout, TestRegisterRoute
 
 
 class TestLoginRouteWithMariaDB(TestLoginRoute):
+    pass
+
+
+class TestLogoutRouteWithMariaDB(TestLogout):
     pass
 
 

--- a/backend/tests/integration_tests/test_auth.py
+++ b/backend/tests/integration_tests/test_auth.py
@@ -1,11 +1,15 @@
-from tests.unit_tests.test_auth import TestLoginRoute, TestLogout, TestRegisterRoute
+from tests.unit_tests.test_auth import (
+    TestLoginRoute,
+    TestLogoutRoute,
+    TestRegisterRoute,
+)
 
 
 class TestLoginRouteWithMariaDB(TestLoginRoute):
     pass
 
 
-class TestLogoutRouteWithMariaDB(TestLogout):
+class TestLogoutRouteWithMariaDB(TestLogoutRoute):
     pass
 
 

--- a/backend/tests/unit_tests/test_auth.py
+++ b/backend/tests/unit_tests/test_auth.py
@@ -336,7 +336,7 @@ class TestVerifyJWT:
         )
 
 
-class TestLogout:
+class TestLogoutRoute:
     def test_if_jwt_exist_should_return_ok(
         self,
         client: FlaskClient,


### PR DESCRIPTION
將 logout route 的單元測試引入到整合測試，確保在 MariaDB 中也能正常運行。

註：[Rename tests of login route](https://github.com/ntut-xuan/FastShop/commit/ca5d0d43613875813b62abad50e83b3053150d1b) 這個 commit 的 message 應該要是 "Rename tests of **logout** route"，不好意思誤植了 😢 
你可以 squash 來消除這個 commit，這個 PR 應該也足夠小，代價不會太大。