### PR TITLE
新增 apidocs 頁面，完成 API 整理文件

### DIFF
--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-FastShop API is an API documentation based on the OpenAPI 3.0 specification. The API documentation page generates by Flasgger.
+FastShop API is an API documentation based on the [OpenAPI 3.0 specification](https://swagger.io/specification/). The API documentation page generates by [Flasgger](https://github.com/flasgger/flasgger).
 
 You can add the YAML file to describe the API, load the YAML file in a specific route with the `swag_from` decorator, and it should present the description in the following link:
 
@@ -12,6 +12,6 @@ http://localhost:8080/apidocs
 
 ## Notice
 
-The YAML file should follow [OpenAPI 3.0 specification](https://swagger.io/specification/)
+The YAML file should follow OpenAPI 3.0 specification.
 
 Furthermore, in this project, we ask the API should follow [REST](https://zh.wikipedia.org/zh-tw/%E8%A1%A8%E7%8E%B0%E5%B1%82%E7%8A%B6%E6%80%81%E8%BD%AC%E6%8D%A2) also.

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-FastShop API is a API documentation based on the OpenAPI 3.0 specification. The API documentation page generate by Flasgger.
+FastShop API is an API documentation based on the OpenAPI 3.0 specification. The API documentation page generates by Flasgger.
 
-You can add the YAML file to describe the API, load the YAML file in specific route with `swag_from` decorator, and it should be present the description of route in the following link:
+You can add the YAML file to describe the API, load the YAML file in a specific route with the `swag_from` decorator, and it should present the description in the following link:
 
 ```
 http://localhost:8080/apidocs
@@ -14,4 +14,4 @@ http://localhost:8080/apidocs
 
 The YAML file should follow [OpenAPI 3.0 specification](https://swagger.io/specification/)
 
-Also, in this project, we ask the API should follow [REST](https://zh.wikipedia.org/zh-tw/%E8%A1%A8%E7%8E%B0%E5%B1%82%E7%8A%B6%E6%80%81%E8%BD%AC%E6%8D%A2) also.
+Furthermore, in this project, we ask the API should follow [REST](https://zh.wikipedia.org/zh-tw/%E8%A1%A8%E7%8E%B0%E5%B1%82%E7%8A%B6%E6%80%81%E8%BD%AC%E6%8D%A2) also.

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -14,4 +14,4 @@ http://localhost:8080/apidocs
 
 The YAML file should follow OpenAPI 3.0 specification.
 
-Furthermore, in this project, we ask the API should follow [REST](https://zh.wikipedia.org/zh-tw/%E8%A1%A8%E7%8E%B0%E5%B1%82%E7%8A%B6%E6%80%81%E8%BD%AC%E6%8D%A2) also.
+Furthermore, in this project, the API should follow [REST](https://zh.wikipedia.org/zh-tw/%E8%A1%A8%E7%8E%B0%E5%B1%82%E7%8A%B6%E6%80%81%E8%BD%AC%E6%8D%A2) also.

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -1,0 +1,17 @@
+# FastShop API
+
+## Description
+
+FastShop API is a API documentation based on the OpenAPI 3.0 specification. The API documentation page generate by Flasgger.
+
+You can add the YAML file to describe the API, load the YAML file in specific route with `swag_from` decorator, and it should be present the description of route in the following link:
+
+```
+http://localhost:8080/apidocs
+```
+
+## Notice
+
+The YAML file should follow [OpenAPI 3.0 specification](https://swagger.io/specification/)
+
+Also, in this project, we ask the API should follow [REST](https://zh.wikipedia.org/zh-tw/%E8%A1%A8%E7%8E%B0%E5%B1%82%E7%8A%B6%E6%80%81%E8%BD%AC%E6%8D%A2) also.

--- a/backend/api/login_get.yml
+++ b/backend/api/login_get.yml
@@ -2,7 +2,7 @@ The login route.
 ---
 tags:
   - auth
-description: Get the login page from backend server.
+description: Get the login page from the backend server.
 responses:
   200:
     description: OK

--- a/backend/api/login_get.yml
+++ b/backend/api/login_get.yml
@@ -1,0 +1,8 @@
+The login route.
+---
+tags:
+  - auth
+description: Get the login page from backend server.
+responses:
+  200:
+    description: OK

--- a/backend/api/login_post.yml
+++ b/backend/api/login_post.yml
@@ -2,7 +2,7 @@ The login route.
 ---
 tags:
   - auth
-description: Post the login payload to backend server.
+description: Post the login payload to the backend server.
 requestBody:
   content:
     application/json:
@@ -60,4 +60,4 @@ definitions:
     properties:
       message:
         type: string
-        description: The response message from server.
+        description: The response message from the server.

--- a/backend/api/login_post.yml
+++ b/backend/api/login_post.yml
@@ -1,0 +1,63 @@
+The login route.
+---
+tags:
+  - auth
+description: Post the login payload to backend server.
+requestBody:
+  content:
+    application/json:
+      schema:
+          $ref: '#/definitions/RequestBody'
+  required: true
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "OK"
+  400:
+    description: The data has the wrong format and the server can't understand it.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "The data has the wrong format and the server can't understand it."
+  403:
+    description: The email or password that the user posted does not match any account.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "The email or password that the user posted does not match any account."
+  422:
+    description: The posted data has the correct format, but the data is invalid.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "The posted data has the correct format, but the data is invalid."
+definitions:
+  RequestBody:
+    type: object
+    required:
+      - e-mail
+      - password
+    properties:
+      e-mail:
+        type: string
+        example: xuan@fsa.net
+      password:
+        type: string
+        example: password
+  ResponseBody:
+    type: object
+    properties:
+      message:
+        type: string
+        description: The response message from server.

--- a/backend/api/logout_post.yml
+++ b/backend/api/logout_post.yml
@@ -1,0 +1,21 @@
+The route to logging out of the account.
+---
+tags:
+  - auth
+description: Log out of the account and delete the jwt token.
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "OK"
+definitions:
+  ResponseBody:
+  type: object
+  properties:
+    message:
+      type: string
+      description: The response message from server.

--- a/backend/api/logout_post.yml
+++ b/backend/api/logout_post.yml
@@ -18,4 +18,4 @@ definitions:
   properties:
     message:
       type: string
-      description: The response message from server.
+      description: The response message from the server.

--- a/backend/api/register_get.yml
+++ b/backend/api/register_get.yml
@@ -2,7 +2,7 @@ The register route.
 ---
 tags:
   - auth
-description: Get the register page from backend server.
+description: Get the register page from the backend server.
 responses:
   200:
     description: OK

--- a/backend/api/register_get.yml
+++ b/backend/api/register_get.yml
@@ -1,0 +1,8 @@
+The register route.
+---
+tags:
+  - auth
+description: Get the register page from backend server.
+responses:
+  200:
+    description: OK

--- a/backend/api/register_post.yml
+++ b/backend/api/register_post.yml
@@ -2,7 +2,7 @@ The register route.
 ---
 tags:
   - auth
-description: Post the register payload to backend server.
+description: Post the register payload to the backend server.
 requestBody:
   content:
     application/json:
@@ -57,10 +57,10 @@ definitions:
         example: password
       firstname:
         type: string
-        example: Huang
+        example: Han-Xuan
       lastname:
         type: string
-        example: Han-Xuan
+        example: Huang
       gender:
         type: int
         enum: [0, 1]
@@ -68,10 +68,10 @@ definitions:
       birthday:
         type: string
         format: date
-        exmaple: "2002-06-25"
+        example: "2002-06-25"
   ResponseBody:
     type: object
     properties:
       message:
         type: string
-        description: The response message from server.
+        description: The response message from the server.

--- a/backend/api/register_post.yml
+++ b/backend/api/register_post.yml
@@ -1,0 +1,77 @@
+The register route.
+---
+tags:
+  - auth
+description: Post the register payload to backend server.
+requestBody:
+  content:
+    application/json:
+      schema:
+          $ref: '#/definitions/RequestBody'
+  required: true
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "OK"
+  400:
+    description: The data has the wrong format and the server can't understand it.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "The data has the wrong format and the server can't understand it."
+  403:
+    description: The email or password that the user posted does not match any account.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "The email or password that the user posted does not match any account."
+  422:
+    description: The posted data has the correct format, but the data is invalid.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "The posted data has the correct format, but the data is invalid."
+definitions:
+  RequestBody:
+    type: object
+    required:
+      - e-mail
+      - password
+    properties:
+      e-mail:
+        type: string
+        example: xuan@fsa.net
+      password:
+        type: string
+        example: password
+      firstname:
+        type: string
+        example: Huang
+      lastname:
+        type: string
+        example: Han-Xuan
+      gender:
+        type: int
+        enum: [0, 1]
+        example: 0
+      birthday:
+        type: string
+        format: date
+        exmaple: "2002-06-25"
+  ResponseBody:
+    type: object
+    properties:
+      message:
+        type: string
+        description: The response message from server.

--- a/backend/api/verify_jwt_post.yml
+++ b/backend/api/verify_jwt_post.yml
@@ -1,0 +1,37 @@
+The route to verify the jwt token.
+---
+tags:
+  - auth
+description: Verify the jwt cookie in the header, if it is absent or invalid should return an error.
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "OK"
+  401:
+    description: The specific cookie does not exist in the request header.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "The specific cookie does not exist in the request header."
+  422:
+    description: The specific cookie in the request header is invalid.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/ResponseBody'
+        example:
+          message: "The specific cookie in the request header is invalid."
+definitions:
+  ResponseBody:
+  type: object
+  properties:
+    message:
+      type: string
+      description: The response message from server.

--- a/backend/api/verify_jwt_post.yml
+++ b/backend/api/verify_jwt_post.yml
@@ -2,7 +2,7 @@ The route to verify the jwt token.
 ---
 tags:
   - auth
-description: Verify the jwt cookie in the header, if it is absent or invalid should return an error.
+description: Verify the jwt cookie in the header. Return 4XX if it does not exist or is invalid.
 responses:
   200:
     description: OK
@@ -34,4 +34,4 @@ definitions:
   properties:
     message:
       type: string
-      description: The response message from server.
+      description: The response message from the server.

--- a/backend/app.py
+++ b/backend/app.py
@@ -3,6 +3,7 @@ from secrets import token_hex
 from typing import Any, Mapping
 
 from flask import Flask
+from flasgger import Swagger
 
 from auth.route import auth_bp
 from database import create_db_command, db
@@ -21,6 +22,20 @@ def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
     # a random key for jwt encoding
     app.config["jwt_key"] = token_hex()
 
+    # For newest swagger UI
+    swagger_config = Swagger.DEFAULT_CONFIG
+    swagger_config[
+        "swagger_ui_bundle_js"
+    ] = "//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-bundle.js"
+    swagger_config[
+        "swagger_ui_standalone_preset_js"
+    ] = "//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-standalone-preset.js"
+    swagger_config["jquery_js"] = "//unpkg.com/jquery@2.2.4/dist/jquery.min.js"
+    swagger_config[
+        "swagger_ui_css"
+    ] = "//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui.css"
+
+    Swagger(app)
     db.init_app(app)
     app.cli.add_command(create_db_command)
     app.register_blueprint(auth_bp)

--- a/backend/app.py
+++ b/backend/app.py
@@ -10,7 +10,31 @@ from database import create_db_command, db
 from util import fetch_page
 
 
-def init_swagger(app: Flask) -> None:
+def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
+    app = Flask(
+        __name__,
+        static_folder=(Path(__file__).parents[1] / "static"),
+    )
+    if test_config is None:
+        app.config.from_pyfile("config.py")
+    else:
+        app.config.from_mapping(test_config)
+    # a random key for jwt encoding
+    app.config["jwt_key"] = token_hex()
+
+    _init_swagger(app)
+    db.init_app(app)
+    app.cli.add_command(create_db_command)
+    app.register_blueprint(auth_bp)
+
+    @app.route("/", methods=["GET"])
+    def index() -> str:
+        return fetch_page("index")
+
+    return app
+
+
+def _init_swagger(app: Flask) -> None:
     swagger_config = Swagger.DEFAULT_CONFIG
     swagger_config[
         "swagger_ui_bundle_js"
@@ -24,27 +48,3 @@ def init_swagger(app: Flask) -> None:
     ] = "//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui.css"
 
     Swagger(app)
-
-
-def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
-    app = Flask(
-        __name__,
-        static_folder=(Path(__file__).parents[1] / "static"),
-    )
-    if test_config is None:
-        app.config.from_pyfile("config.py")
-    else:
-        app.config.from_mapping(test_config)
-    # a random key for jwt encoding
-    app.config["jwt_key"] = token_hex()
-
-    init_swagger(app)
-    db.init_app(app)
-    app.cli.add_command(create_db_command)
-    app.register_blueprint(auth_bp)
-
-    @app.route("/", methods=["GET"])
-    def index() -> str:
-        return fetch_page("index")
-
-    return app

--- a/backend/app.py
+++ b/backend/app.py
@@ -10,19 +10,7 @@ from database import create_db_command, db
 from util import fetch_page
 
 
-def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
-    app = Flask(
-        __name__,
-        static_folder=(Path(__file__).parents[1] / "static"),
-    )
-    if test_config is None:
-        app.config.from_pyfile("config.py")
-    else:
-        app.config.from_mapping(test_config)
-    # a random key for jwt encoding
-    app.config["jwt_key"] = token_hex()
-
-    # For newest swagger UI
+def init_swagger(app: Flask) -> None:
     swagger_config = Swagger.DEFAULT_CONFIG
     swagger_config[
         "swagger_ui_bundle_js"
@@ -36,6 +24,21 @@ def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
     ] = "//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui.css"
 
     Swagger(app)
+
+
+def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
+    app = Flask(
+        __name__,
+        static_folder=(Path(__file__).parents[1] / "static"),
+    )
+    if test_config is None:
+        app.config.from_pyfile("config.py")
+    else:
+        app.config.from_mapping(test_config)
+    # a random key for jwt encoding
+    app.config["jwt_key"] = token_hex()
+
+    init_swagger(app)
     db.init_app(app)
     app.cli.add_command(create_db_command)
     app.register_blueprint(auth_bp)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from secrets import token_hex
-from typing import Any, Mapping
+from typing import Any, Mapping, Final
 
 from flasgger import Swagger
 from flask import Flask
@@ -35,16 +35,23 @@ def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
 
 
 def _init_swagger(app: Flask) -> None:
+    SWAGGER_UI_VERSION: Final[str] = "4.15.5"
+    JQUERY_VERSION: Final[str] = "3.6.1"
+
+    SWAGGER_UI_DIST_URL: Final[
+        str
+    ] = f"//unpkg.com/swagger-ui-dist@{SWAGGER_UI_VERSION}"
+
     swagger_config = Swagger.DEFAULT_CONFIG
     swagger_config[
         "swagger_ui_bundle_js"
-    ] = "//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-bundle.js"
+    ] = f"{SWAGGER_UI_DIST_URL}/swagger-ui-bundle.js"
     swagger_config[
         "swagger_ui_standalone_preset_js"
-    ] = "//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-standalone-preset.js"
-    swagger_config["jquery_js"] = "//unpkg.com/jquery@2.2.4/dist/jquery.min.js"
+    ] = f"{SWAGGER_UI_DIST_URL}/swagger-ui-standalone-preset.js"
+    swagger_config["swagger_ui_css"] = f"{SWAGGER_UI_DIST_URL}/swagger-ui.css"
     swagger_config[
-        "swagger_ui_css"
-    ] = "//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui.css"
+        "jquery_js"
+    ] = f"//unpkg.com/jquery@{JQUERY_VERSION}/dist/jquery.min.js"
 
     Swagger(app)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from secrets import token_hex
-from typing import Any, Mapping, Final
+from typing import Any, Final, Mapping
 
 from flasgger import Swagger
 from flask import Flask

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from secrets import token_hex
 from typing import Any, Mapping
 
-from flask import Flask
 from flasgger import Swagger
+from flask import Flask
 
 from auth.route import auth_bp
 from database import create_db_command, db

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
 
+from flasgger import swag_from
 from flask import Blueprint, Response, current_app, make_response, request
 
 from auth.exception import EmailAlreadyRegisteredError
@@ -35,6 +36,8 @@ auth_bp = Blueprint("auth", __name__)
 
 
 @auth_bp.route("/login", methods=["GET", "POST"])
+@swag_from("../api/login_get.yml", methods=["GET"])
+@swag_from("../api/login_post.yml", methods=["POST"])
 def login_route() -> Response | str:
     if request.method == "POST":
         data = request.json
@@ -67,6 +70,8 @@ def login_route() -> Response | str:
 
 
 @auth_bp.route("/register", methods=["GET", "POST"])
+@swag_from("../api/register_get.yml", methods=["GET"])
+@swag_from("../api/register_post.yml", methods=["POST"])
 def register_route() -> Response | str:
     if request.method == "POST":
         # 400 Bad Request error will automatically be raised

--- a/backend/auth/route.py
+++ b/backend/auth/route.py
@@ -117,6 +117,7 @@ def register_route() -> Response | str:
 
 
 @auth_bp.route("/verify_jwt", methods=["POST"])
+@swag_from("../api/verify_jwt_post.yml", methods=["POST"])
 def verify_jwt_route() -> Response:
     if "jwt" not in request.cookies:
         return _make_single_message_response(HTTPStatus.UNAUTHORIZED, ABSENT_COOKIE)
@@ -134,6 +135,7 @@ def verify_jwt_route() -> Response:
 
 
 @auth_bp.route("/logout", methods=["POST"])
+@swag_from("../api/logout_post.yml", methods=["POST"])
 def logout_route() -> Response:
     response: Response = _make_single_message_response(HTTPStatus.OK)
     response.delete_cookie("jwt")

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,3 +7,10 @@ SQLALCHEMY_DATABASE_URI: str = (
         password=quote("@fsa2022")
     )
 )
+SWAGGER = {
+    "title": "FastShop API",
+    "uiversion": "3",
+    "openapi": "3.0.3",
+    "termsOfService": "",
+    "description": "This is a FastShop API based on the OpenAPI 3.0 specification.",
+}

--- a/backend/config.py
+++ b/backend/config.py
@@ -12,5 +12,6 @@ SWAGGER = {
     "uiversion": "3",
     "openapi": "3.0.3",
     "termsOfService": "",
+    "version": "0.1.0",
     "description": "This is a FastShop API based on the OpenAPI 3.0 specification.",
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ types-setuptools==65.5.0.3
 typing_extensions==4.3.0
 virtualenv==20.16.5
 Werkzeug==2.2.2
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click==8.1.3
 coverage==6.5.0
 distlib==0.3.6
 filelock==3.8.0
+flasgger==0.9.5
 Flask==2.2.2
 Flask-SQLAlchemy==3.0.2
 freezegun==1.2.2
@@ -13,7 +14,9 @@ identify==2.5.5
 iniconfig==1.1.1
 itsdangerous==2.1.2
 Jinja2==3.1.2
+jsonschema==4.17.1
 MarkupSafe==2.1.1
+mistune==2.0.4
 mypy==0.971
 mypy-extensions==0.4.3
 nodeenv==1.7.0
@@ -40,4 +43,3 @@ types-setuptools==65.5.0.3
 typing_extensions==4.3.0
 virtualenv==20.16.5
 Werkzeug==2.2.2
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
### Brief Description

我們在這個 PR 中，引入了 Swagger API documentation 來幫助設計 API 的說明文件。

我們引入了 OpenAPI 3.0.2，以及 Swagger UI 4.15.5 兩個最新的版本。

### The one thing you should do before you review the PR

使用 `pip` 安裝 `flasgger`，使用指令 `pip install flasgger` 來安裝。

### The things we finish in this PR

 - 完成目前的 6 個 `route` 文件建置。
 - 使目前的 `apidocs` 頁面可以正常運作，使用 `http://localhost:8080/apidocs/` 來連入。

![image](https://user-images.githubusercontent.com/69747731/204565860-94fc0d72-5725-4c40-9ac8-78d091689526.png)

也許未來可以引入 Restful API 的機制？

Resolved: #72 