### PR TITLE
修復錯誤的 docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.13.0'
+version: "3.8"
 
 services:
   mariadb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '0.0.1'
+version: '2.13.0'
 
 services:
   mariadb:


### PR DESCRIPTION
當前的 docker compose 版本是無效的，應修正為最新版 `2.13.0`。

Resolved: #74 