### PR TITLE
修復 virtualenv 版本過舊導致 pre-commit 無法使用的問題

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,6 @@ toml==0.10.2
 tomli==2.0.1
 types-PyMySQL==1.0.19
 typing_extensions==4.3.0
-virtualenv==20.16.5
+virtualenv==20.17.0
 Werkzeug==2.2.2
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
將 `virtualenv==20.16.5` 更新成 `virtualenv==20.17.0`，問題即可解決。

Resolved: #78 