### PR TITLE
完成 tags 的 API 描述

### DIFF
--- a/backend/api/tags_get.yml
+++ b/backend/api/tags_get.yml
@@ -15,10 +15,9 @@ definitions:
   tags:
     type: object
     properties:
-      total:
-        description: The total of the tags.
+      count:
         type: integer
-        example: 1
+        example: 4
       items:
         type: array
         description: The array contains all the tags.

--- a/backend/api/tags_get.yml
+++ b/backend/api/tags_get.yml
@@ -1,0 +1,35 @@
+The route to get all the tags.
+---
+tags:
+  - tags
+description: "The route to get all the tags."
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/tags'
+
+definitions:
+  tags:
+    type: object
+    properties:
+      total:
+        description: The total of the tags.
+        type: integer
+        example: 1
+      items:
+        type: array
+        description: The array contains all the tags.
+        items:
+          $ref: '#/definitions/tag_response'
+  tag_response:
+    type: object
+    properties:
+      id:
+        type: integer
+        example: 3325
+      name:
+        type: string
+        example: dian

--- a/backend/api/tags_get.yml
+++ b/backend/api/tags_get.yml
@@ -1,7 +1,7 @@
 The route to get all the tags.
 ---
 tags:
-  - tags
+  - tag
 description: The route to get all the tags.
 responses:
   200:

--- a/backend/api/tags_get.yml
+++ b/backend/api/tags_get.yml
@@ -18,7 +18,7 @@ definitions:
       count:
         type: integer
         example: 4
-      items:
+      tags:
         type: array
         description: The array contains all the tags.
         items:

--- a/backend/api/tags_get.yml
+++ b/backend/api/tags_get.yml
@@ -2,7 +2,7 @@ The route to get all the tags.
 ---
 tags:
   - tags
-description: "The route to get all the tags."
+description: The route to get all the tags.
 responses:
   200:
     description: OK

--- a/backend/api/tags_id_delete.yml
+++ b/backend/api/tags_id_delete.yml
@@ -19,7 +19,7 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: "OK"
+          message: OK
   402:
     description: Unauthorized.
     content:

--- a/backend/api/tags_id_delete.yml
+++ b/backend/api/tags_id_delete.yml
@@ -1,9 +1,9 @@
-The route to delete specific ID of tag.
+The route to delete the tag of a specific ID.
 ---
 tags:
   - tag
 
-description: "The route to delete specific ID of tag. \n\n Return `4XX` if the operation fail. (See Responses section below)"
+description: "The route to delete the tag of a specific ID. \n\n Return `4XX` if the operation fails. (See Responses section below)"
 
 parameters:
   - in: path
@@ -29,10 +29,10 @@ responses:
         example:
           message: Unauthorized.
   403:
-    description: The specific ID of tag is absent.
+    description: The specific ID of the tag is absent.
     content:
       application/json:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: The specific ID of tag is absent.
+          message: The specific ID of the tag is absent.

--- a/backend/api/tags_id_delete.yml
+++ b/backend/api/tags_id_delete.yml
@@ -1,7 +1,7 @@
 The route to delete specific ID of tag.
 ---
 tags:
-  - tags
+  - tag
 
 description: "The route to delete specific ID of tag. \n\n Return `4XX` if the operation fail. (See Responses section below)"
 

--- a/backend/api/tags_id_delete.yml
+++ b/backend/api/tags_id_delete.yml
@@ -1,0 +1,38 @@
+The route to delete specific ID of tag.
+---
+tags:
+  - tags
+
+description: "The route to delete specific ID of tag. \n\n Return `4XX` if the operation fail. (See Responses section below)"
+
+parameters:
+  - in: path
+    name: id
+    type: integer
+    example: 3325
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "OK"
+  402:
+    description: Unauthorized.
+    content:
+      application/json:
+        schema:
+          $ref: "#/definitions/message"
+        example:
+          message: Unauthorized.
+  403:
+    description: The specific ID of tag is absent.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: The specific ID of tag is absent.

--- a/backend/api/tags_id_get.yml
+++ b/backend/api/tags_id_get.yml
@@ -1,7 +1,7 @@
 The route to get specific ID of tag.
 ---
 tags:
-  - tags
+  - tag
 
 description: "The route to get specific ID of tag. \n\n Return `403` if the specific ID of tag is absent."
 

--- a/backend/api/tags_id_get.yml
+++ b/backend/api/tags_id_get.yml
@@ -1,0 +1,28 @@
+The route to get specific ID of tag.
+---
+tags:
+  - tags
+
+description: "The route to get specific ID of tag. \n\n Return `403` if the specific ID of tag is absent."
+
+parameters:
+  - in: path
+    name: id
+    type: integer
+    example: 3325
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/tag_response'
+  403:
+    description: The specific ID of tag is absent.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: The specific ID of tag is absent.

--- a/backend/api/tags_id_get.yml
+++ b/backend/api/tags_id_get.yml
@@ -1,9 +1,9 @@
-The route to get specific ID of tag.
+The route to get the tag of a specific ID.
 ---
 tags:
   - tag
 
-description: "The route to get specific ID of tag. \n\n Return `403` if the specific ID of tag is absent."
+description: "The route to get the tag of a specific ID. \n\n Return `403` if the specific ID of the tag is absent."
 
 parameters:
   - in: path

--- a/backend/api/tags_id_items_get.yml
+++ b/backend/api/tags_id_items_get.yml
@@ -1,0 +1,28 @@
+The route to get all the items which have specific tag.
+---
+tags:
+  - tags
+
+description: "The route to get all the items which have specific tag. \n\n Return `403` if the specific ID of tag is absent."
+
+parameters:
+  - in: path
+    name: id
+    type: integer
+    example: 3325
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/tag_response'
+  403:
+    description: The specific ID of tag is absent.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: The specific ID of tag is absent.

--- a/backend/api/tags_id_items_get.yml
+++ b/backend/api/tags_id_items_get.yml
@@ -1,7 +1,7 @@
 The route to get all the items which have specific tag.
 ---
 tags:
-  - tags
+  - tag
 
 description: "The route to get all the items which have specific tag. \n\n Return `403` if the specific ID of tag is absent."
 

--- a/backend/api/tags_id_items_get.yml
+++ b/backend/api/tags_id_items_get.yml
@@ -1,9 +1,9 @@
-The route to get all the items which have specific tag.
+The route to get all the items which have a specific tag.
 ---
 tags:
   - tag
 
-description: "The route to get all the items which have specific tag. \n\n Return `403` if the specific ID of tag is absent."
+description: "The route to get all the items which have a specific tag. \n\n Return `403` if the specific ID of the tag is absent."
 
 parameters:
   - in: path
@@ -19,10 +19,10 @@ responses:
         schema:
           $ref: '#/definitions/tag_response'
   403:
-    description: The specific ID of tag is absent.
+    description: The specific ID of the tag is absent.
     content:
       application/json:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: The specific ID of tag is absent.
+          message: The specific ID of the tag is absent.

--- a/backend/api/tags_id_items_get.yml
+++ b/backend/api/tags_id_items_get.yml
@@ -17,7 +17,7 @@ responses:
     content:
       application/json:
         schema:
-          $ref: '#/definitions/tag_response'
+          $ref: '#/definitions/items'
   403:
     description: The specific ID of the tag is absent.
     content:
@@ -26,3 +26,53 @@ responses:
           $ref: '#/definitions/message'
         example:
           message: The specific ID of the tag is absent.
+
+definitions:
+  items:
+    type: object
+    properties:
+      count:
+        description: The count of the items.
+        type: integer
+        example: 1
+      items:
+        type: array
+        description: The array contains all the items.
+        items:
+          $ref: '#/definitions/item_response'
+  item_response:
+    type: object
+    properties:
+      id:
+        type: string
+        example: 41092554
+      count:
+        type: integer
+        example: 44
+      name:
+        type: string
+        example: Entropy
+      price:
+        type: object
+        properties:
+          discount:
+            type: integer
+            example: 43210
+          original:
+            type: integer
+            example: 48763
+      avatars:
+        type: array
+        items:
+          type: string
+        description: The avatars of the item. It's a list of URLs.
+        example:
+          - http://localhost/500x500/item_41092554.png
+      tags: # TODO: It can be ref if tags definitions exist. (#90)
+        type: array
+        items:
+          type: string
+        description: The tags of the item. It's a list of tag objects.
+        example:
+        - id: 33
+          name: dian

--- a/backend/api/tags_id_put.yml
+++ b/backend/api/tags_id_put.yml
@@ -1,0 +1,61 @@
+The route to update specific ID of tag.
+---
+tags:
+  - tags
+
+description: "The route to update specific ID of tag. \n\n Return `4XX` if the operation fail. (See Responses section below)"
+
+parameters:
+  - in: path
+    name: id
+    type: integer
+    example: 3325
+
+requestBody:
+  content:
+    application/json:
+      schema:
+          $ref: '#/definitions/tag_payload'
+  required: true
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "OK"
+  400:
+    description: The data has the wrong format and the server can't understand it.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "The data has the wrong format and the server can't understand it."
+  402:
+    description: Unauthorized.
+    content:
+      application/json:
+        schema:
+          $ref: "#/definitions/message"
+        example:
+          message: Unauthorized.
+  403:
+    description: The specific ID of tag is absent.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: The specific ID of tag is absent.
+  422:
+    description: The posted data has the correct format, but the data is invalid.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "The posted data has the correct format, but the data is invalid."

--- a/backend/api/tags_id_put.yml
+++ b/backend/api/tags_id_put.yml
@@ -1,9 +1,9 @@
-The route to update specific ID of tag.
+The route to update the tag of a specific ID.
 ---
 tags:
   - tag
 
-description: "The route to update specific ID of tag. \n\n Return `4XX` if the operation fail. (See Responses section below)"
+description: "The route to update the tag of a specific ID. \n\n Return `4XX` if the operation fails. (See Responses section below)"
 
 parameters:
   - in: path
@@ -44,13 +44,13 @@ responses:
         example:
           message: Unauthorized.
   403:
-    description: The specific ID of tag is absent.
+    description: The specific ID of the tag is absent.
     content:
       application/json:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: The specific ID of tag is absent.
+          message: The specific ID of the tag is absent.
   422:
     description: The posted data has the correct format, but the data is invalid.
     content:

--- a/backend/api/tags_id_put.yml
+++ b/backend/api/tags_id_put.yml
@@ -1,7 +1,7 @@
 The route to update specific ID of tag.
 ---
 tags:
-  - tags
+  - tag
 
 description: "The route to update specific ID of tag. \n\n Return `4XX` if the operation fail. (See Responses section below)"
 

--- a/backend/api/tags_id_put.yml
+++ b/backend/api/tags_id_put.yml
@@ -34,7 +34,7 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: "The data has the wrong format and the server can't understand it."
+          message: The data has the wrong format and the server can't understand it.
   402:
     description: Unauthorized.
     content:
@@ -58,4 +58,4 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: "The posted data has the correct format, but the data is invalid."
+          message: The posted data has the correct format, but the data is invalid.

--- a/backend/api/tags_id_put.yml
+++ b/backend/api/tags_id_put.yml
@@ -26,7 +26,7 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: "OK"
+          message: OK
   400:
     description: The data has the wrong format and the server can't understand it.
     content:

--- a/backend/api/tags_post.yml
+++ b/backend/api/tags_post.yml
@@ -1,0 +1,67 @@
+The route to add a tag.
+---
+tags:
+  - tags
+description: "The route to add a tag. \n\n Return `4XX` if data invalid, tag exist or unauthorized."
+
+requestBody:
+  content:
+    application/json:
+      schema:
+          $ref: '#/definitions/tag_payload'
+  required: true
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "OK"
+  400:
+    description: The data has the wrong format and the server can't understand it.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "The data has the wrong format and the server can't understand it."
+  402:
+    description: Unauthorized.
+    content:
+      application/json:
+        schema:
+          $ref: "#/definitions/message"
+        example:
+          message: Unauthorized.
+  403:
+    description: The tag already exists in the database.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: The tag already exists in the database.
+  422:
+    description: The posted data has the correct format, but the data is invalid.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "The posted data has the correct format, but the data is invalid."
+
+definitions:
+  tag_payload:
+    type: object
+    properties:
+      name:
+        type: string
+        example: dian
+  message:
+    type: object
+    properties:
+      message:
+        type: string

--- a/backend/api/tags_post.yml
+++ b/backend/api/tags_post.yml
@@ -1,7 +1,7 @@
 The route to add a tag.
 ---
 tags:
-  - tags
+  - tag
 description: "The route to add a tag. \n\n Return `4XX` if data invalid, tag exist or unauthorized."
 
 requestBody:

--- a/backend/api/tags_post.yml
+++ b/backend/api/tags_post.yml
@@ -19,7 +19,7 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: "OK"
+          message: OK
   400:
     description: The data has the wrong format and the server can't understand it.
     content:

--- a/backend/api/tags_post.yml
+++ b/backend/api/tags_post.yml
@@ -2,7 +2,7 @@ The route to add a tag.
 ---
 tags:
   - tag
-description: "The route to add a tag. \n\n Return `4XX` if data invalid, tag exist or unauthorized."
+description: "The route to add a tag. \n\n Return `4XX` if the data is invalid, the tag exists, or is unauthorized."
 
 requestBody:
   content:

--- a/backend/api/tags_post.yml
+++ b/backend/api/tags_post.yml
@@ -27,7 +27,7 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: "The data has the wrong format and the server can't understand it."
+          message: The data has the wrong format and the server can't understand it.
   402:
     description: Unauthorized.
     content:
@@ -51,7 +51,7 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: "The posted data has the correct format, but the data is invalid."
+          message: The posted data has the correct format, but the data is invalid.
 
 definitions:
   tag_payload:

--- a/backend/app.py
+++ b/backend/app.py
@@ -6,8 +6,8 @@ from flasgger import Swagger
 from flask import Flask
 
 from auth.route import auth_bp
-from tag.route import tag_bp
 from database import create_db_command, db
+from tag.route import tag_bp
 from util import fetch_page
 
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -6,6 +6,7 @@ from flasgger import Swagger
 from flask import Flask
 
 from auth.route import auth_bp
+from tag.route import tag_bp
 from database import create_db_command, db
 from util import fetch_page
 
@@ -26,6 +27,7 @@ def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
     db.init_app(app)
     app.cli.add_command(create_db_command)
     app.register_blueprint(auth_bp)
+    app.register_blueprint(tag_bp)
 
     @app.route("/", methods=["GET"])
     def index() -> str:

--- a/backend/tag/route.py
+++ b/backend/tag/route.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from flasgger import swag_from
+from flask import Blueprint
+
+tag_bp = Blueprint("tag", __name__)
+
+
+@tag_bp.route("/tags", methods=["GET"])
+@swag_from("../api/tags_get.yml")
+def fetch_all_tags():
+    pass  # pragma: no cover
+
+
+@tag_bp.route("/tags", methods=["POST"])
+@swag_from("../api/tags_post.yml")
+def add_tag():
+    pass  # pragma: no cover
+
+
+@tag_bp.route("/tags/<string:id>", methods=["GET"])
+@swag_from("../api/tags_id_get.yml")
+def fetch_tag(id):
+    pass  # pragma: no cover
+
+
+@tag_bp.route("/tags/<string:id>", methods=["PUT"])
+@swag_from("../api/tags_id_put.yml")
+def update_tag(id):
+    pass  # pragma: no cover
+
+
+@tag_bp.route("/tags/<string:id>", methods=["DELETE"])
+@swag_from("../api/tags_id_delete.yml")
+def delete_tag(id):
+    pass  # pragma: no cover
+
+
+@tag_bp.route("/tags/<string:id>/items", methods=["GET"])
+@swag_from("../api/tags_id_items_get.yml")
+def get_items_by_tag(id):
+    pass  # pragma: no cover


### PR DESCRIPTION
## Brief Description

在這份 PR 中，我們帶來了有關 `tags` 的初步描述以及 function signature。

## Preview

Checkout 到這個 branch，接著使用瀏覽器打開 `http://localhost:8080/apidocs`。

## What's new?

新增了六個 `tags` 的介面。

 - `GET /tags/`：取得所有 tag。
 - `POST /tags/`：新增一個 tag。
 - `GET /tags/{id}/` 根據 tag ID 取得一個 tag。
 - `PUT /tags/{id}/` 根據 tag ID 更新一個 tag。
 - `DELETE /tags/{id}/` 根據 tag ID 刪除一個 tag。
 - `GET /tags/{id}/items/` 根據 tag ID 取得所有具有該 tag 的物品。

## Postscript

由於我英文頗爛，請幫我注意一下文法問題，感恩 orz

Resolved: #82 