### PR TITLE
完成靜態圖片介面的 API documentation

### DIFF
--- a/backend/api/static/static_images_id_delete.yml
+++ b/backend/api/static/static_images_id_delete.yml
@@ -8,7 +8,7 @@ description: "Delete the image with a specific ID. \n\n `4XX` if the operation f
 parameters:
   - in: path
     name: id
-    description: The ID of the item which you want to delete.
+    description: The ID of the image which you want to delete.
     schema:
       type: string
     required: true

--- a/backend/api/static/static_images_id_delete.yml
+++ b/backend/api/static/static_images_id_delete.yml
@@ -1,0 +1,40 @@
+Delete image with specific ID.
+---
+tags:
+  - static
+
+description: "Delete image with specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
+
+parameters:
+  - in: path
+    name: id
+    description: The ID of item which you want to query.
+    schema:
+      type: string
+    required: true
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "OK"
+  402:
+    description: Unauthorized.
+    content:
+      application/json:
+        schema:
+          $ref: "#/definitions/message"
+        example:
+          message: Unauthorized.
+  403:
+    description: The image query by the ID is absent.
+    content:
+      application/json:
+        schema:
+          $ref: "#/definitions/message"
+        example:
+          message: The specific image is absent.

--- a/backend/api/static/static_images_id_delete.yml
+++ b/backend/api/static/static_images_id_delete.yml
@@ -21,7 +21,7 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: "OK"
+          message: OK
   402:
     description: Unauthorized.
     content:

--- a/backend/api/static/static_images_id_delete.yml
+++ b/backend/api/static/static_images_id_delete.yml
@@ -1,14 +1,14 @@
-Delete image with specific ID.
+Delete the image with a specific ID.
 ---
 tags:
   - static
 
-description: "Delete image with specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
+description: "Delete the image with a specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
 
 parameters:
   - in: path
     name: id
-    description: The ID of item which you want to query.
+    description: The ID of the item which you want to delete.
     schema:
       type: string
     required: true
@@ -31,10 +31,10 @@ responses:
         example:
           message: Unauthorized.
   403:
-    description: The image query by the ID is absent.
+    description: The image with a specific ID is absent.
     content:
       application/json:
         schema:
           $ref: "#/definitions/message"
         example:
-          message: The specific image is absent.
+          message: The image with a specific ID is absent.

--- a/backend/api/static/static_images_id_get.yml
+++ b/backend/api/static/static_images_id_get.yml
@@ -1,13 +1,13 @@
-Fetch image with specific ID.
+Fetch the image with a specific ID.
 ---
 tags:
   - static
-description: Fetch image with specific ID.
+description: Fetch the image with a specific ID.
 
 parameters:
   - in: path
     name: id
-    description: The ID of image which you want to query.
+    description: The ID of the image which you want to fetch.
     schema:
       type: string
     required: true
@@ -17,13 +17,13 @@ responses:
     description: OK
     content:
       image/png:
-        schema: 
+        schema:
           type: string
           format: binary
   403:
-    description: The image with specific ID is absent.
+    description: The image with a specific ID is absent.
     content:
       plain/text:
         schema:
           type: string
-          example: The image with specific ID is absent.
+          example: The image with a specific ID is absent.

--- a/backend/api/static/static_images_id_get.yml
+++ b/backend/api/static/static_images_id_get.yml
@@ -1,0 +1,29 @@
+Fetch image with specific ID.
+---
+tags:
+  - static
+description: Fetch image with specific ID.
+
+parameters:
+  - in: path
+    name: id
+    description: The ID of image which you want to query.
+    schema:
+      type: string
+    required: true
+
+responses:
+  200:
+    description: OK
+    content:
+      image/png:
+        schema: 
+          type: string
+          format: binary
+  403:
+    description: The image with specific ID is absent.
+    content:
+      plain/text:
+        schema:
+          type: string
+          example: The image with specific ID is absent.

--- a/backend/api/static/static_images_id_put.yml
+++ b/backend/api/static/static_images_id_put.yml
@@ -1,0 +1,56 @@
+Update image with specific ID.
+---
+tags:
+  - static
+
+description: "Update image with specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
+
+parameters:
+  - in: path
+    name: id
+    description: The ID of item which you want to query.
+    schema:
+      type: string
+    required: true
+
+requestBody:
+  content:
+    text/plain:
+      schema:
+          type: string
+          format: binary
+  required: true
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "OK"
+  400:
+    description: The data has the wrong format and the server can't understand it.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: The data has the wrong format and the server can't understand it.
+  402:
+    description: Unauthorized.
+    content:
+      application/json:
+        schema:
+          $ref: "#/definitions/message"
+        example:
+          message: Unauthorized.
+  403:
+    description: The image query by the ID is absent.
+    content:
+      application/json:
+        schema:
+          $ref: "#/definitions/message"
+        example:
+          message: The specific image is absent.

--- a/backend/api/static/static_images_id_put.yml
+++ b/backend/api/static/static_images_id_put.yml
@@ -8,7 +8,7 @@ description: "Update the image with a specific ID. \n\n `4XX` if the operation f
 parameters:
   - in: path
     name: id
-    description: The ID of the item which you want to query.
+    description: The ID of the item which you want to update.
     schema:
       type: string
     required: true

--- a/backend/api/static/static_images_id_put.yml
+++ b/backend/api/static/static_images_id_put.yml
@@ -8,7 +8,7 @@ description: "Update the image with a specific ID. \n\n `4XX` if the operation f
 parameters:
   - in: path
     name: id
-    description: The ID of the item which you want to update.
+    description: The ID of the image which you want to update.
     schema:
       type: string
     required: true

--- a/backend/api/static/static_images_id_put.yml
+++ b/backend/api/static/static_images_id_put.yml
@@ -1,14 +1,14 @@
-Update image with specific ID.
+Update the image with a specific ID.
 ---
 tags:
   - static
 
-description: "Update image with specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
+description: "Update the image with a specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
 
 parameters:
   - in: path
     name: id
-    description: The ID of item which you want to query.
+    description: The ID of the item which you want to query.
     schema:
       type: string
     required: true
@@ -47,10 +47,10 @@ responses:
         example:
           message: Unauthorized.
   403:
-    description: The image query by the ID is absent.
+    description: The image with a specific ID is absent.
     content:
       application/json:
         schema:
           $ref: "#/definitions/message"
         example:
-          message: The specific image is absent.
+          message: The image with a specific ID is absent.

--- a/backend/api/static/static_images_id_put.yml
+++ b/backend/api/static/static_images_id_put.yml
@@ -29,7 +29,7 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: "OK"
+          message: OK
   400:
     description: The data has the wrong format and the server can't understand it.
     content:

--- a/backend/api/static/static_images_post.yml
+++ b/backend/api/static/static_images_post.yml
@@ -24,7 +24,7 @@ responses:
           id:
             type: string
         example:
-          id: 22045569
+          id: 59cb70a7-51e0-4e33-b942-e6ea1bba20fa
   400:
     description: The data has the wrong format and the server can't understand it.
     content:

--- a/backend/api/static/static_images_post.yml
+++ b/backend/api/static/static_images_post.yml
@@ -1,4 +1,4 @@
-Update the image with a specific ID.
+Update the base64 of the item.
 ---
 tags:
   - static

--- a/backend/api/static/static_images_post.yml
+++ b/backend/api/static/static_images_post.yml
@@ -1,0 +1,40 @@
+Update image with specific ID.
+---
+tags:
+  - static
+
+description: "Update base64 of image with specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
+
+requestBody:
+  content:
+    text/plain:
+      schema:
+          type: string
+          example: data:image/png;base64,...
+  required: true
+
+responses:
+  200:
+    description: OK
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: "OK"
+  400:
+    description: The data has the wrong format and the server can't understand it.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: The data has the wrong format and the server can't understand it.
+  402:
+    description: Unauthorized.
+    content:
+      application/json:
+        schema:
+          $ref: "#/definitions/message"
+        example:
+          message: Unauthorized.

--- a/backend/api/static/static_images_post.yml
+++ b/backend/api/static/static_images_post.yml
@@ -19,9 +19,12 @@ responses:
     content:
       application/json:
         schema:
-          $ref: '#/definitions/message'
+          message:
+            type: string
+          id:
+            type: string
         example:
-          message: "OK"
+          id: 22045569
   400:
     description: The data has the wrong format and the server can't understand it.
     content:

--- a/backend/api/static/static_images_post.yml
+++ b/backend/api/static/static_images_post.yml
@@ -3,7 +3,7 @@ Update the image with a specific ID.
 tags:
   - static
 
-description: "Update base64 of the image with a specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
+description: "Update the base64 of the image. \n\n `4XX` if the operation fails. (See Response section below)"
 
 requestBody:
   content:

--- a/backend/api/static/static_images_post.yml
+++ b/backend/api/static/static_images_post.yml
@@ -1,9 +1,9 @@
-Update image with specific ID.
+Update the image with a specific ID.
 ---
 tags:
   - static
 
-description: "Update base64 of image with specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
+description: "Update base64 of the image with a specific ID. \n\n `4XX` if the operation fails. (See Response section below)"
 
 requestBody:
   content:

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,7 @@ from flask import Flask
 from auth.route import auth_bp
 from database import create_db_command, db
 from item.route import item_bp
+from static.route import static_bp
 from tag.route import tag_bp
 from util import fetch_page
 
@@ -29,6 +30,7 @@ def create_app(test_config: Mapping[str, Any] | None = None) -> Flask:
     app.cli.add_command(create_db_command)
     app.register_blueprint(auth_bp)
     app.register_blueprint(item_bp)
+    app.register_blueprint(static_bp)
     app.register_blueprint(tag_bp)
 
     @app.route("/", methods=["GET"])

--- a/backend/static/route.py
+++ b/backend/static/route.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from flasgger import swag_from
+from flask import Blueprint
+
+static_bp = Blueprint("static", __name__)
+
+
+@static_bp.route("/static/images/<string:id>", methods=["GET"])
+@swag_from("../api/static/static_images_id_get.yml")
+def fetch_image_with_specific_id(id):
+    pass  # pragma: no cover
+
+
+@static_bp.route("/static/images", methods=["POST"])
+@swag_from("../api/static/static_images_post.yml")
+def upload_image():
+    pass  # pragma: no cover
+
+
+@static_bp.route("/static/images/<string:id>", methods=["PUT"])
+@swag_from("../api/static/static_images_id_put.yml")
+def modify_image_with_specific_id(id):
+    pass  # pragma: no cover
+
+
+@static_bp.route("/static/images/<string:id>", methods=["DELETE"])
+@swag_from("../api/static/static_images_id_delete.yml")
+def delete_image_with_specific_id(id):
+    pass  # pragma: no cover


### PR DESCRIPTION
## What's new?

我們完成了靜態圖片介面的 API documentation，預計會使圖片可以透過 RESTful API 的形式進行 CRUD 的操作。

預計新增四個 route：
 - `GET /static/images/{id}`：取得特定圖片（如果成功，回傳 `image/png` mimetype 的資料）。
 - `POST /static/images`：上傳圖片的 base64。
 - `DELETE /static/images/{id}`：刪除特定圖片。
 - `PUT /static/images/{id}`：更新特定圖片。