### PR TITLE
在 dockerfile 上加上新增資料夾，供給靜態檔案存放資料

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN npm -v
 # setup repository file to /etc/fastshop
 RUN mkdir /etc/fastshop
 COPY . /etc/fastshop
+# make var-path directory to store static file.
+RUN mkdir /var/fastshop
+RUN mkdir /var/fastshop/image
 # install tailwindcss and react.js from npm
 WORKDIR /etc/fastshop
 RUN npm install -D tailwindcss


### PR DESCRIPTION
## What's new?

在這個 PR 中，我們在 dockerfile 上加上了 `mkdir /var/fastshop` 與 `mkdir /var/fastshop/image` 這兩行指令，來創立資料夾存放圖片的靜態資料，並且能夠在後端介面上存取這些檔案。