### PR TITLE
Create models of item and tag

### DIFF
--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import sqlite3
 from typing import Final
 
 import click
 from flask import current_app
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 
 
 db: Final[SQLAlchemy] = SQLAlchemy()
@@ -12,6 +15,17 @@ db: Final[SQLAlchemy] = SQLAlchemy()
 # For SQLAlchemy.create_all to know what to create.
 # NOTE: imports after the creation of "db" to resolve circular import
 from models import User
+
+
+# SQLite does not work with foreign key by default.
+# The PRAGMA for enablement must be emitted on all connections before use.
+# See https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#foreign-key-support
+@event.listens_for(Engine, "connect")
+def set_sqlite_pragma(dbapi_connection, _):
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cursor: sqlite3.Cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
 
 @click.command("create-db")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,7 +1,5 @@
 from database import db
 
-from sqlalchemy.engine.default import DefaultExecutionContext
-
 
 class User(db.Model):  # type: ignore
     uid = db.Column(db.Integer, primary_key=True, autoincrement=True)
@@ -21,7 +19,10 @@ class Tag(db.Model):  # type: ignore
 
 
 def same_as(column_name: str):
-    def default_function(context: DefaultExecutionContext):
+    def default_function(context):
+        # context seems to be in type "sqlalchemy.engine.default.DefaultExecutionContext"
+        # from the doc, but mypy says no
+        # See https://docs.sqlalchemy.org/en/20/core/internals.html#sqlalchemy.engine.default.DefaultExecutionContext.current_parameters
         return context.current_parameters.get(column_name)
 
     return default_function

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -38,3 +38,22 @@ class Item(db.Model):  # type: ignore
     avatar = db.Column(db.String(36))  # 36 character long uuid
 
     __table_args__ = (db.CheckConstraint(count > 0),)
+
+
+class TagOfItem(db.Model):  # type: ignore
+    item_id = db.Column(
+        db.ForeignKey(
+            Item.id,
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        primary_key=True,
+    )
+    tag_id = db.Column(
+        db.ForeignKey(
+            Tag.id,
+            ondelete="CASCADE",
+            onupdate="CASCADE",
+        ),
+        primary_key=True,
+    )

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -11,3 +11,8 @@ class User(db.Model):  # type: ignore
     birthday = db.Column(db.Integer, nullable=False)  # timestamp
 
     __table_args__ = (db.CheckConstraint(gender.in_({0, 1})),)
+
+
+class Tag(db.Model):  # type: ignore
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    name = db.Column(db.String(100), nullable=False)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,5 +1,7 @@
 from database import db
 
+from sqlalchemy.engine.default import DefaultExecutionContext
+
 
 class User(db.Model):  # type: ignore
     uid = db.Column(db.Integer, primary_key=True, autoincrement=True)
@@ -16,3 +18,23 @@ class User(db.Model):  # type: ignore
 class Tag(db.Model):  # type: ignore
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String(100), nullable=False)
+
+
+def same_as(column_name: str):
+    def default_function(context: DefaultExecutionContext):
+        return context.current_parameters.get(column_name)
+
+    return default_function
+
+
+class Item(db.Model):  # type: ignore
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    name = db.Column(db.String(100), nullable=False)
+    count = db.Column(db.Integer, default=0, nullable=False)
+    original = db.Column(db.Integer, nullable=False)
+    discount = db.Column(
+        db.Integer, default=same_as("original"), nullable=False
+    )  # price after discounted
+    avatar = db.Column(db.String(36))  # 36 character long uuid
+
+    __table_args__ = (db.CheckConstraint(count > 0),)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -15,7 +15,7 @@ class User(db.Model):  # type: ignore
 
 class Tag(db.Model):  # type: ignore
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    name = db.Column(db.String(100), nullable=False)
+    name = db.Column(db.String(100), unique=True)
 
 
 def same_as(column_name: str):

--- a/backend/tests/integration_tests/test_model.py
+++ b/backend/tests/integration_tests/test_model.py
@@ -1,0 +1,7 @@
+from tests.unit_tests.test_model import TestCascadeUpdateAndDeleteOnTagOfItem
+
+
+class TestCascadeUpdateAndDeleteOnTagOfItemWithMariaDB(
+    TestCascadeUpdateAndDeleteOnTagOfItem
+):
+    pass

--- a/backend/tests/unit_tests/test_model.py
+++ b/backend/tests/unit_tests/test_model.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from operator import attrgetter
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy.sql.expression import Select
+
+from database import db
+from models import Item, Tag, TagOfItem
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+
+@pytest.fixture(autouse=True)
+def insert_test_data(app: Flask) -> None:
+    with app.app_context():
+        db.session.execute(
+            db.insert(Item),
+            [
+                {
+                    "id": 1,
+                    "name": "apple",
+                    "count": 10,
+                    "original": 30,
+                    "discount": 25,
+                    "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
+                },
+                {
+                    "id": 2,
+                    "name": "tilapia",
+                    "count": 3,
+                    "original": 50,
+                    "discount": 45,
+                    "avatar": "xx-S0m3-aVA7aR-0f-ti1a9iA-xx",
+                },
+            ],
+        )
+        db.session.execute(
+            db.insert(Tag),
+            [
+                {"id": 1, "name": "fruit"},
+                {"id": 2, "name": "fish"},
+                {"id": 3, "name": "grocery"},
+            ],
+        )
+        db.session.execute(
+            db.insert(TagOfItem),
+            [
+                {"item_id": 1, "tag_id": 1},
+                {"item_id": 2, "tag_id": 2},
+                {"item_id": 1, "tag_id": 3},
+                {"item_id": 2, "tag_id": 3},
+            ],
+        )
+        db.session.commit()
+
+
+def test_update_on_tag_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
+    # delete the id of (5, "fish") to 5
+    with app.app_context():
+        id_of_fish_tag = 2
+        db.session.execute(db.update(Tag).where(Tag.id == id_of_fish_tag).values(id=5))
+        db.session.commit()
+
+    # "tilapia" should now have a tag with id 5, which is "fish"
+    with app.app_context():
+        id_of_tilapia = 2
+        stmt: Select = db.select(TagOfItem.tag_id).where(
+            TagOfItem.item_id == id_of_tilapia
+        )
+        tag_ids_of_tilapia = list(
+            map(attrgetter("tag_id"), db.session.execute(stmt).fetchall())
+        )
+        assert 5 in tag_ids_of_tilapia
+
+
+def test_delete_on_tag_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
+    # delete the (2, "fish") tag
+    with app.app_context():
+        id_of_fish_tag = 2
+        db.session.execute(db.delete(Tag).where(Tag.id == id_of_fish_tag))
+        db.session.commit()
+
+    # tilapia should no longer have a tag with id 2
+    with app.app_context():
+        id_of_tilapia = 2
+        stmt: Select = db.select(TagOfItem.tag_id).where(
+            TagOfItem.item_id == id_of_tilapia
+        )
+        tag_ids_of_tilapia = set(
+            map(attrgetter("tag_id"), db.session.execute(stmt).fetchall())
+        )
+        assert tag_ids_of_tilapia == set([3])
+
+
+def test_delete_on_item_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
+    # delete the item "apple", which has id 1
+    with app.app_context():
+        id_of_apple_tag = 1
+        db.session.execute(db.delete(Item).where(Item.id == id_of_apple_tag))
+        db.session.commit()
+
+    # fruit should no longer have a item with id 1
+    with app.app_context():
+        id_of_fruit = 1
+        stmt: Select = db.select(TagOfItem.item_id).where(
+            TagOfItem.tag_id == id_of_fruit
+        )
+        item_ids_of_fruit = set(
+            map(attrgetter("item_id"), db.session.execute(stmt).fetchall())
+        )
+        assert item_ids_of_fruit == set()

--- a/backend/tests/unit_tests/test_model.py
+++ b/backend/tests/unit_tests/test_model.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from operator import attrgetter
-from typing import TYPE_CHECKING
+from typing import Final, TYPE_CHECKING
 
 import pytest
 from sqlalchemy.sql.expression import Select
@@ -59,96 +58,94 @@ class TestCascadeUpdateAndDeleteOnTagOfItem:
 
     def test_update_on_tag_should_be_cascaded_to_tag_of_item(self, app: Flask) -> None:
         # update the id of (2, "fish") to 5
+        original_id_of_fish_tag: Final = 2
+        updated_id_of_fish_tag: Final = 5
         with app.app_context():
-            id_of_fish_tag = 2
             db.session.execute(
-                db.update(Tag).where(Tag.id == id_of_fish_tag).values(id=5)
+                db.update(Tag)
+                .where(Tag.id == original_id_of_fish_tag)
+                .values(id=updated_id_of_fish_tag)
             )
             db.session.commit()
 
         # "tilapia" should now have a tag with id 5, which is "fish"
         with app.app_context():
-            id_of_tilapia = 2
+            id_of_tilapia: Final = 2
             stmt: Select = db.select(TagOfItem.tag_id).where(
                 TagOfItem.item_id == id_of_tilapia
             )
-            tag_ids_of_tilapia = list(
-                map(attrgetter("tag_id"), db.session.execute(stmt).fetchall())
-            )
-            assert 5 in tag_ids_of_tilapia
+            tag_ids_of_tilapia: list[int] = db.session.execute(stmt).scalars().all()
+
+            assert updated_id_of_fish_tag in tag_ids_of_tilapia
 
     def test_update_on_item_should_be_cascaded_to_tag_of_item(self, app: Flask) -> None:
         # update the id of item (1, "apple") to 3
+        original_id_of_apple_item: Final = 1
+        updated_id_of_apple_item: Final = 3
         with app.app_context():
-            id_of_apple_item = 1
             db.session.execute(
-                db.update(Item).where(Item.id == id_of_apple_item).values(id=3)
+                db.update(Item)
+                .where(Item.id == original_id_of_apple_item)
+                .values(id=updated_id_of_apple_item)
             )
             db.session.commit()
 
         # "fruit" should now have a item with id 3, which is "apple"
         with app.app_context():
-            id_of_fruit = 1
+            id_of_fruit: Final = 1
             stmt: Select = db.select(TagOfItem.item_id).where(
                 TagOfItem.tag_id == id_of_fruit
             )
-            item_ids_of_fruit = list(
-                map(attrgetter("item_id"), db.session.execute(stmt).fetchall())
-            )
-            assert 3 in item_ids_of_fruit
+            item_ids_of_fruit: list[int] = db.session.execute(stmt).scalars().all()
+
+            assert updated_id_of_apple_item in item_ids_of_fruit
 
     def test_delete_on_tag_should_be_cascaded_to_tag_of_item(self, app: Flask) -> None:
         # delete the (2, "fish") tag
+        id_of_fish_tag: Final = 2
         with app.app_context():
-            id_of_fish_tag = 2
             db.session.execute(db.delete(Tag).where(Tag.id == id_of_fish_tag))
             db.session.commit()
 
         # tilapia should no longer have a tag with id 2
         with app.app_context():
-            id_of_tilapia = 2
+            id_of_tilapia: Final = 2
             stmt: Select = db.select(TagOfItem.tag_id).where(
                 TagOfItem.item_id == id_of_tilapia
             )
-            tag_ids_of_tilapia = set(
-                map(attrgetter("tag_id"), db.session.execute(stmt).fetchall())
-            )
-            assert tag_ids_of_tilapia == set([3])
+            tag_ids_of_tilapia: list[int] = db.session.execute(stmt).scalars().all()
+            assert id_of_fish_tag not in tag_ids_of_tilapia
 
     def test_delete_on_item_should_be_cascaded_to_tag_of_item(self, app: Flask) -> None:
         # delete the item "apple", which has id 1
+        id_of_apple_tag: Final = 1
         with app.app_context():
-            id_of_apple_tag = 1
             db.session.execute(db.delete(Item).where(Item.id == id_of_apple_tag))
             db.session.commit()
 
         # fruit should no longer have a item with id 1
         with app.app_context():
-            id_of_fruit = 1
+            id_of_fruit: Final = 1
             stmt: Select = db.select(TagOfItem.item_id).where(
                 TagOfItem.tag_id == id_of_fruit
             )
-            item_ids_of_fruit = set(
-                map(attrgetter("item_id"), db.session.execute(stmt).fetchall())
-            )
-            assert item_ids_of_fruit == set()
+            item_ids_of_fruit: list[int] = db.session.execute(stmt).scalars().all()
+
+            assert id_of_apple_tag not in item_ids_of_fruit
 
 
 def test_item_discount_should_be_as_same_as_original_if_not_given(app: Flask) -> None:
-    original = 30
+    original: Final = 30
     with app.app_context():
         db.session.execute(
-            db.insert(Item),
-            [
-                {
-                    "id": 1,
-                    "name": "apple",
-                    "count": 10,
-                    "original": original,
-                    # no discount,
-                    "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
-                },
-            ],
+            db.insert(Item).values(
+                id=1,
+                name="apple",
+                count=10,
+                original=original,
+                # no discount,
+                avatar="xx-S0m3-aVA7aR-0f-a991e-xx",
+            ),
         )
         db.session.commit()
 

--- a/backend/tests/unit_tests/test_model.py
+++ b/backend/tests/unit_tests/test_model.py
@@ -58,7 +58,7 @@ def insert_test_data(app: Flask) -> None:
 
 
 def test_update_on_tag_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
-    # delete the id of (5, "fish") to 5
+    # update the id of (2, "fish") to 5
     with app.app_context():
         id_of_fish_tag = 2
         db.session.execute(db.update(Tag).where(Tag.id == id_of_fish_tag).values(id=5))
@@ -74,6 +74,27 @@ def test_update_on_tag_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
             map(attrgetter("tag_id"), db.session.execute(stmt).fetchall())
         )
         assert 5 in tag_ids_of_tilapia
+
+
+def test_update_on_item_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
+    # update the id of item (1, "apple") to 3
+    with app.app_context():
+        id_of_apple_item = 1
+        db.session.execute(
+            db.update(Item).where(Item.id == id_of_apple_item).values(id=3)
+        )
+        db.session.commit()
+
+    # "fruit" should now have a item with id 3, which is "apple"
+    with app.app_context():
+        id_of_fruit = 1
+        stmt: Select = db.select(TagOfItem.item_id).where(
+            TagOfItem.tag_id == id_of_fruit
+        )
+        item_ids_of_fruit = list(
+            map(attrgetter("item_id"), db.session.execute(stmt).fetchall())
+        )
+        assert 3 in item_ids_of_fruit
 
 
 def test_delete_on_tag_should_be_cascaded_to_tag_of_item(app: Flask) -> None:

--- a/backend/tests/unit_tests/test_model.py
+++ b/backend/tests/unit_tests/test_model.py
@@ -132,3 +132,28 @@ class TestCascadeUpdateAndDeleteOnTagOfItem:
                 map(attrgetter("item_id"), db.session.execute(stmt).fetchall())
             )
             assert item_ids_of_fruit == set()
+
+
+def test_item_discount_should_be_as_same_as_original_if_not_given(app: Flask) -> None:
+    original = 30
+    with app.app_context():
+        db.session.execute(
+            db.insert(Item),
+            [
+                {
+                    "id": 1,
+                    "name": "apple",
+                    "count": 10,
+                    "original": original,
+                    # no discount,
+                    "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
+                },
+            ],
+        )
+        db.session.commit()
+
+    with app.app_context():
+        select_discount_stmt: Select = db.select(Item.discount).where(Item.id == 1)
+        discount: int = db.session.execute(select_discount_stmt).scalar_one()
+
+        assert discount == original

--- a/backend/tests/unit_tests/test_model.py
+++ b/backend/tests/unit_tests/test_model.py
@@ -13,123 +13,122 @@ if TYPE_CHECKING:
     from flask import Flask
 
 
-@pytest.fixture(autouse=True)
-def insert_test_data(app: Flask) -> None:
-    with app.app_context():
-        db.session.execute(
-            db.insert(Item),
-            [
-                {
-                    "id": 1,
-                    "name": "apple",
-                    "count": 10,
-                    "original": 30,
-                    "discount": 25,
-                    "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
-                },
-                {
-                    "id": 2,
-                    "name": "tilapia",
-                    "count": 3,
-                    "original": 50,
-                    "discount": 45,
-                    "avatar": "xx-S0m3-aVA7aR-0f-ti1a9iA-xx",
-                },
-            ],
-        )
-        db.session.execute(
-            db.insert(Tag),
-            [
-                {"id": 1, "name": "fruit"},
-                {"id": 2, "name": "fish"},
-                {"id": 3, "name": "grocery"},
-            ],
-        )
-        db.session.execute(
-            db.insert(TagOfItem),
-            [
-                {"item_id": 1, "tag_id": 1},
-                {"item_id": 2, "tag_id": 2},
-                {"item_id": 1, "tag_id": 3},
-                {"item_id": 2, "tag_id": 3},
-            ],
-        )
-        db.session.commit()
+class TestCascadeUpdateAndDeleteOnTagOfItem:
+    @pytest.fixture(autouse=True)
+    def insert_test_data(self, app: Flask) -> None:
+        with app.app_context():
+            db.session.execute(
+                db.insert(Item),
+                [
+                    {
+                        "id": 1,
+                        "name": "apple",
+                        "count": 10,
+                        "original": 30,
+                        "discount": 25,
+                        "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
+                    },
+                    {
+                        "id": 2,
+                        "name": "tilapia",
+                        "count": 3,
+                        "original": 50,
+                        "discount": 45,
+                        "avatar": "xx-S0m3-aVA7aR-0f-ti1a9iA-xx",
+                    },
+                ],
+            )
+            db.session.execute(
+                db.insert(Tag),
+                [
+                    {"id": 1, "name": "fruit"},
+                    {"id": 2, "name": "fish"},
+                    {"id": 3, "name": "grocery"},
+                ],
+            )
+            db.session.execute(
+                db.insert(TagOfItem),
+                [
+                    {"item_id": 1, "tag_id": 1},
+                    {"item_id": 2, "tag_id": 2},
+                    {"item_id": 1, "tag_id": 3},
+                    {"item_id": 2, "tag_id": 3},
+                ],
+            )
+            db.session.commit()
 
+    def test_update_on_tag_should_be_cascaded_to_tag_of_item(self, app: Flask) -> None:
+        # update the id of (2, "fish") to 5
+        with app.app_context():
+            id_of_fish_tag = 2
+            db.session.execute(
+                db.update(Tag).where(Tag.id == id_of_fish_tag).values(id=5)
+            )
+            db.session.commit()
 
-def test_update_on_tag_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
-    # update the id of (2, "fish") to 5
-    with app.app_context():
-        id_of_fish_tag = 2
-        db.session.execute(db.update(Tag).where(Tag.id == id_of_fish_tag).values(id=5))
-        db.session.commit()
+        # "tilapia" should now have a tag with id 5, which is "fish"
+        with app.app_context():
+            id_of_tilapia = 2
+            stmt: Select = db.select(TagOfItem.tag_id).where(
+                TagOfItem.item_id == id_of_tilapia
+            )
+            tag_ids_of_tilapia = list(
+                map(attrgetter("tag_id"), db.session.execute(stmt).fetchall())
+            )
+            assert 5 in tag_ids_of_tilapia
 
-    # "tilapia" should now have a tag with id 5, which is "fish"
-    with app.app_context():
-        id_of_tilapia = 2
-        stmt: Select = db.select(TagOfItem.tag_id).where(
-            TagOfItem.item_id == id_of_tilapia
-        )
-        tag_ids_of_tilapia = list(
-            map(attrgetter("tag_id"), db.session.execute(stmt).fetchall())
-        )
-        assert 5 in tag_ids_of_tilapia
+    def test_update_on_item_should_be_cascaded_to_tag_of_item(self, app: Flask) -> None:
+        # update the id of item (1, "apple") to 3
+        with app.app_context():
+            id_of_apple_item = 1
+            db.session.execute(
+                db.update(Item).where(Item.id == id_of_apple_item).values(id=3)
+            )
+            db.session.commit()
 
+        # "fruit" should now have a item with id 3, which is "apple"
+        with app.app_context():
+            id_of_fruit = 1
+            stmt: Select = db.select(TagOfItem.item_id).where(
+                TagOfItem.tag_id == id_of_fruit
+            )
+            item_ids_of_fruit = list(
+                map(attrgetter("item_id"), db.session.execute(stmt).fetchall())
+            )
+            assert 3 in item_ids_of_fruit
 
-def test_update_on_item_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
-    # update the id of item (1, "apple") to 3
-    with app.app_context():
-        id_of_apple_item = 1
-        db.session.execute(
-            db.update(Item).where(Item.id == id_of_apple_item).values(id=3)
-        )
-        db.session.commit()
+    def test_delete_on_tag_should_be_cascaded_to_tag_of_item(self, app: Flask) -> None:
+        # delete the (2, "fish") tag
+        with app.app_context():
+            id_of_fish_tag = 2
+            db.session.execute(db.delete(Tag).where(Tag.id == id_of_fish_tag))
+            db.session.commit()
 
-    # "fruit" should now have a item with id 3, which is "apple"
-    with app.app_context():
-        id_of_fruit = 1
-        stmt: Select = db.select(TagOfItem.item_id).where(
-            TagOfItem.tag_id == id_of_fruit
-        )
-        item_ids_of_fruit = list(
-            map(attrgetter("item_id"), db.session.execute(stmt).fetchall())
-        )
-        assert 3 in item_ids_of_fruit
+        # tilapia should no longer have a tag with id 2
+        with app.app_context():
+            id_of_tilapia = 2
+            stmt: Select = db.select(TagOfItem.tag_id).where(
+                TagOfItem.item_id == id_of_tilapia
+            )
+            tag_ids_of_tilapia = set(
+                map(attrgetter("tag_id"), db.session.execute(stmt).fetchall())
+            )
+            assert tag_ids_of_tilapia == set([3])
 
+    def test_delete_on_item_should_be_cascaded_to_tag_of_item(self, app: Flask) -> None:
+        # delete the item "apple", which has id 1
+        with app.app_context():
+            id_of_apple_tag = 1
+            db.session.execute(db.delete(Item).where(Item.id == id_of_apple_tag))
+            db.session.commit()
 
-def test_delete_on_tag_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
-    # delete the (2, "fish") tag
-    with app.app_context():
-        id_of_fish_tag = 2
-        db.session.execute(db.delete(Tag).where(Tag.id == id_of_fish_tag))
-        db.session.commit()
-
-    # tilapia should no longer have a tag with id 2
-    with app.app_context():
-        id_of_tilapia = 2
-        stmt: Select = db.select(TagOfItem.tag_id).where(
-            TagOfItem.item_id == id_of_tilapia
-        )
-        tag_ids_of_tilapia = set(
-            map(attrgetter("tag_id"), db.session.execute(stmt).fetchall())
-        )
-        assert tag_ids_of_tilapia == set([3])
-
-
-def test_delete_on_item_should_be_cascaded_to_tag_of_item(app: Flask) -> None:
-    # delete the item "apple", which has id 1
-    with app.app_context():
-        id_of_apple_tag = 1
-        db.session.execute(db.delete(Item).where(Item.id == id_of_apple_tag))
-        db.session.commit()
-
-    # fruit should no longer have a item with id 1
-    with app.app_context():
-        id_of_fruit = 1
-        stmt: Select = db.select(TagOfItem.item_id).where(
-            TagOfItem.tag_id == id_of_fruit
-        )
-        item_ids_of_fruit = set(
-            map(attrgetter("item_id"), db.session.execute(stmt).fetchall())
-        )
-        assert item_ids_of_fruit == set()
+        # fruit should no longer have a item with id 1
+        with app.app_context():
+            id_of_fruit = 1
+            stmt: Select = db.select(TagOfItem.item_id).where(
+                TagOfItem.tag_id == id_of_fruit
+            )
+            item_ids_of_fruit = set(
+                map(attrgetter("item_id"), db.session.execute(stmt).fetchall())
+            )
+            assert item_ids_of_fruit == set()


### PR DESCRIPTION
## What's new?

新增了 3 個 table，分別是 `item`, `tag` 和 `tag_of_item`。
因為 `item` 與 `tag`  是多對多的關係，所以使用額外的 `tag_of_item` 來記錄。

### SQL statements

這些 table 是用 SQLAlchemy 的 interface 建立的，實際執行轉換成 SQL 後有以下敘述：

```sql
CREATE TABLE item (
    id INTEGER NOT NULL AUTO_INCREMENT, 
    name VARCHAR(100) NOT NULL, 
    count INTEGER NOT NULL, 
    original INTEGER NOT NULL, 
    discount INTEGER NOT NULL, 
    avatar VARCHAR(36), 
    PRIMARY KEY (id), 
    CHECK (count > 0)
)

CREATE TABLE tag (
    id INTEGER NOT NULL, 
    name VARCHAR(100), 
    PRIMARY KEY (id), 
    UNIQUE (name)
)


CREATE TABLE tag_of_item (
    item_id INTEGER NOT NULL, 
    tag_id INTEGER NOT NULL, 
    PRIMARY KEY (item_id, tag_id), 
    FOREIGN KEY(item_id) REFERENCES item (id) ON DELETE CASCADE ON UPDATE CASCADE, 
    FOREIGN KEY(tag_id) REFERENCES tag (id) ON DELETE CASCADE ON UPDATE CASCADE
)
```

### Tables

table 建立後於 MariaDB 中 `DESCRIBE` 的樣子如下：

```
item
+----------+--------------+------+-----+---------+----------------+
| Field    | Type         | Null | Key | Default | Extra          |
+----------+--------------+------+-----+---------+----------------+
| id       | int(11)      | NO   | PRI | NULL    | auto_increment |
| name     | varchar(100) | NO   |     | NULL    |                |
| count    | int(11)      | NO   |     | NULL    |                |
| original | int(11)      | NO   |     | NULL    |                |
| discount | int(11)      | NO   |     | NULL    |                |
| avatar   | varchar(36)  | YES  |     | NULL    |                |
+----------+--------------+------+-----+---------+----------------+

tag
+-------+--------------+------+-----+---------+----------------+
| Field | Type         | Null | Key | Default | Extra          |
+-------+--------------+------+-----+---------+----------------+
| id    | int(11)      | NO   | PRI | NULL    | auto_increment |
| name  | varchar(100) | YES  | UNI | NULL    |                |
+-------+--------------+------+-----+---------+----------------+

tag_of_item
+---------+---------+------+-----+---------+-------+
| Field   | Type    | Null | Key | Default | Extra |
+---------+---------+------+-----+---------+-------+
| item_id | int(11) | NO   | PRI | NULL    |       |
| tag_id  | int(11) | NO   | PRI | NULL    |       |
+---------+---------+------+-----+---------+-------+
```

## How has This been tested?

4 組測資針對 foreign key 的 ON DELETE CASCADE 和 ON UPDATE CASCADE 去確認，在 SQLite 與 MariaDB 環境下皆通過測試。

- [x] `item` 上的 `UPDATE` 會 cascade 到 `tag_of_item` 
- [x] `item` 上的 `DELETE` 會 cascade 到 `tag_of_item`
- [x] `tag` 上的 `UPDATE` 會 cascade 到 `tag_of_item` 
- [x] `tag` 上的 `DELETE` 會 cascade 到 `tag_of_item`

**NOTE**: SQLite 預設不受 foreign key 的關聯影響，因此有針對 database 是 SQLite 的場合特別設定。

Resolves: #84 