### PR TITLE
將 API 文件中 item 的 avatar 改為單值並以 UUID 取代 URL

### DIFF
--- a/backend/api/item/items/get.yml
+++ b/backend/api/item/items/get.yml
@@ -19,7 +19,7 @@ responses:
             price:
               discount: 43210
               original: 48763
-            avatar: http://localhost/500x500/item_41092554.png
+            avatar: f692073a-7ac1-11ed-a1eb-0242ac120002
             tags:
               - id: 33
                 name: dian
@@ -59,7 +59,7 @@ definitions:
       avatar:
         type: string
         description: The uuid of the avatar.
-        example: http://localhost/500x500/item_41092554.png
+        example: f692073a-7ac1-11ed-a1eb-0242ac120002
       tags: # TODO: It can be ref if tags definitions exist. (#90)
         type: array
         items:

--- a/backend/api/item/items/get.yml
+++ b/backend/api/item/items/get.yml
@@ -58,7 +58,7 @@ definitions:
             example: 48763
       avatar:
         type: string
-        description: The uuid of the avatar.
+        description: The UUID of the avatar.
         example: f692073a-7ac1-11ed-a1eb-0242ac120002
       tags: # TODO: It can be ref if tags definitions exist. (#90)
         type: array

--- a/backend/api/item/items/get.yml
+++ b/backend/api/item/items/get.yml
@@ -19,8 +19,7 @@ responses:
             price:
               discount: 43210
               original: 48763
-            avatars:
-              - http://localhost/500x500/item_41092554.png
+            avatar: http://localhost/500x500/item_41092554.png
             tags:
               - id: 33
                 name: dian
@@ -57,13 +56,10 @@ definitions:
           original:
             type: integer
             example: 48763
-      avatars:
-        type: array
-        items:
-          type: string
-        description: The avatars of the item. It's a list of URLs.
-        example:
-          - http://localhost/500x500/item_41092554.png
+      avatar:
+        type: string
+        description: The uuid of the avatar.
+        example: http://localhost/500x500/item_41092554.png
       tags: # TODO: It can be ref if tags definitions exist. (#90)
         type: array
         items:

--- a/backend/api/item/items/post.yml
+++ b/backend/api/item/items/post.yml
@@ -81,7 +81,7 @@ definitions:
       avatar:
         type: string
         description: The uuid of the avatar.
-        example: http://localhost/500x500/item_41092554.png
+        example: f692073a-7ac1-11ed-a1eb-0242ac120002
       tags: # TODO: It can be ref if tags definitions exist. (#90)
         type: array
         items:

--- a/backend/api/item/items/post.yml
+++ b/backend/api/item/items/post.yml
@@ -80,7 +80,7 @@ definitions:
             example: 48763
       avatar:
         type: string
-        description: The uuid of the avatar.
+        description: The UUID of the avatar.
         example: f692073a-7ac1-11ed-a1eb-0242ac120002
       tags: # TODO: It can be ref if tags definitions exist. (#90)
         type: array

--- a/backend/api/item/items/post.yml
+++ b/backend/api/item/items/post.yml
@@ -78,13 +78,10 @@ definitions:
           original:
             type: integer
             example: 48763
-      avatars:
-        type: array
-        items:
-          type: string
-        description: The avatars of the item. It's a list of URLs.
-        example:
-          - http://localhost/500x500/item_41092554.png
+      avatar:
+        type: string
+        description: The uuid of the avatar.
+        example: http://localhost/500x500/item_41092554.png
       tags: # TODO: It can be ref if tags definitions exist. (#90)
         type: array
         items:

--- a/backend/api/tag/tags/id/items/get.yml
+++ b/backend/api/tag/tags/id/items/get.yml
@@ -64,7 +64,7 @@ definitions:
       avatar:
         type: string
         description: The uuid of the avatar.
-        example: http://localhost/500x500/item_41092554.png
+        example: f692073a-7ac1-11ed-a1eb-0242ac120002
       tags: # TODO: It can be ref if tags definitions exist. (#90)
         type: array
         items:

--- a/backend/api/tag/tags/id/items/get.yml
+++ b/backend/api/tag/tags/id/items/get.yml
@@ -63,7 +63,7 @@ definitions:
             example: 48763
       avatar:
         type: string
-        description: The uuid of the avatar.
+        description: The UUID of the avatar.
         example: f692073a-7ac1-11ed-a1eb-0242ac120002
       tags: # TODO: It can be ref if tags definitions exist. (#90)
         type: array

--- a/backend/api/tag/tags/id/items/get.yml
+++ b/backend/api/tag/tags/id/items/get.yml
@@ -61,13 +61,10 @@ definitions:
           original:
             type: integer
             example: 48763
-      avatars:
-        type: array
-        items:
-          type: string
-        description: The avatars of the item. It's a list of URLs.
-        example:
-          - http://localhost/500x500/item_41092554.png
+      avatar:
+        type: string
+        description: The uuid of the avatar.
+        example: http://localhost/500x500/item_41092554.png
       tags: # TODO: It can be ref if tags definitions exist. (#90)
         type: array
         items:


### PR DESCRIPTION
會經手 item 的 route 有 4 個
- `GET /items`
- `POST /items`
- `PUT /items/{id}`
- `GET /tags/{id}/items`

更新了 example 和 schema 中的 type。

Resolves: #99 