### PR TITLE
調整 static 的 utility，新增 function 以支援更多操作

### DIFF
--- a/backend/tests/unit_tests/conftest.py
+++ b/backend/tests/unit_tests/conftest.py
@@ -19,10 +19,12 @@ if TYPE_CHECKING:
 @pytest.fixture
 def app() -> Generator[Flask, None, None]:
     db_fp, db_path = tempfile.mkstemp()
+    static_path: str = tempfile.mkdtemp()
     app: Flask = create_app(
         {
             "TESTING": True,
             "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_path}",
+            "STATIC_RESOURCE_PATH": static_path,
         }
     )
     with app.app_context():


### PR DESCRIPTION
## What's new?

在這個 PR 中，我對 static utility 做了以下的調整：

 - 調整 `write_image`，變成 `write_image_with_byte_data`，以寫入 byte 的資料為主。
 - 新增 `get_image_byte_from_existing_file` 來取得存在的圖片的資料。
 - 新增 `get_image_byte_data_from_base64_content` 來從 base64 的圖片資料（`data:image/png;base64...`）來解析出 byte 的資料。
 - 新增 `verify_image_data` 來驗證圖片資料的格式是否正確。