### PR TITLE
Ignore type error on specific error code

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,7 +1,7 @@
 from database import db
 
 
-class User(db.Model):  # type: ignore
+class User(db.Model):  # type: ignore[name-defined]
     uid = db.Column(db.Integer, primary_key=True, autoincrement=True)
     email = db.Column(db.String(100), unique=True)
     password = db.Column(db.String(1000), nullable=False)
@@ -13,7 +13,7 @@ class User(db.Model):  # type: ignore
     __table_args__ = (db.CheckConstraint(gender.in_({0, 1})),)
 
 
-class Tag(db.Model):  # type: ignore
+class Tag(db.Model):  # type: ignore[name-defined]
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String(100), unique=True)
 
@@ -28,7 +28,7 @@ def same_as(column_name: str):
     return default_function
 
 
-class Item(db.Model):  # type: ignore
+class Item(db.Model):  # type: ignore[name-defined]
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.String(100), nullable=False)
     count = db.Column(db.Integer, default=0, nullable=False)
@@ -41,7 +41,7 @@ class Item(db.Model):  # type: ignore
     __table_args__ = (db.CheckConstraint(count > 0),)
 
 
-class TagOfItem(db.Model):  # type: ignore
+class TagOfItem(db.Model):  # type: ignore[name-defined]
     item_id = db.Column(
         db.ForeignKey(
             Item.id,

--- a/backend/static/util.py
+++ b/backend/static/util.py
@@ -53,7 +53,7 @@ def get_file_path_by_image_uuid(uuid: str) -> Path:
     Returns:
         Path: The path object contains the path of image file.
     """
-    static_resource_path: str = current_app.config.get("STATIC_RESOURCE_PATH")  # type: ignore
+    static_resource_path: str = current_app.config.get("STATIC_RESOURCE_PATH")  # type: ignore[assignment]
     path = Path(f"{static_resource_path}/{uuid}.png")
     return path
 

--- a/backend/tests/unit_tests/auth/test_auth.py
+++ b/backend/tests/unit_tests/auth/test_auth.py
@@ -289,7 +289,7 @@ class TestVerifyJWT:
         resp: TestResponse = client.post("/verify_jwt")
 
         assert resp.is_json
-        assert resp.json["data"] == payload  # type: ignore
+        assert resp.json["data"] == payload  # type: ignore[index]
 
     def test_post_with_absent_jwt_cookie_should_have_code_http_unauthorized(
         self,
@@ -307,7 +307,7 @@ class TestVerifyJWT:
 
         assert resp.is_json
         assert (
-            resp.json["message"]  # type: ignore
+            resp.json["message"]  # type: ignore[index]
             == "The specific cookie does not exist in the request header."
         )
 
@@ -331,7 +331,7 @@ class TestVerifyJWT:
 
         assert resp.is_json
         assert (
-            resp.json["message"]  # type: ignore
+            resp.json["message"]  # type: ignore[index]
             == "The specific cookie in the request header is invalid."
         )
 

--- a/backend/tests/unit_tests/static/test_static.py
+++ b/backend/tests/unit_tests/static/test_static.py
@@ -49,7 +49,7 @@ def add_image(logged_in_client: FlaskClient) -> SomeImage:
     )
 
     # ignore type because response.json returns "Any | None" but we're sure it's a string
-    uuid: str = response.json["uuid"]  # type: ignore
+    uuid: str = response.json["uuid"]  # type: ignore[index]
     image_byte_data: bytes = get_image_byte_data_from_base64_content(
         base64_image_content
     )
@@ -258,7 +258,7 @@ class TestImageRoute:
         # [Assert] It should return HTTP status code FORBIDDEN.
         response_data = cast(dict, response.json)
         assert response.status_code == HTTPStatus.FORBIDDEN
-        assert response_data["message"] == ABSENT_IMAGE_WITH_SPECIFIC_UUID  # type: ignore
+        assert response_data["message"] == ABSENT_IMAGE_WITH_SPECIFIC_UUID
 
     def test_delete_image_with_exist_uuid_should_delete_successfully(
         self, app: Flask, logged_in_client: FlaskClient, add_image: SomeImage

--- a/backend/tests/unit_tests/test_util.py
+++ b/backend/tests/unit_tests/test_util.py
@@ -132,6 +132,6 @@ class TestRouteWithDocDecorator:
         # disable swag_from since it's irrelevant in this test
         monkeypatch.setattr("util.swag_from", lambda *x, **y: self.dummy_func)
         # monkeypatch route for the assertion
-        test_bp.route = self.RulePassedToRouteShouldNotChangeFunctor(rule)  # type: ignore
+        test_bp.route = self.RulePassedToRouteShouldNotChangeFunctor(rule)  # type: ignore[assignment]
 
         route_with_doc(test_bp, rule, methods=["GET"])(self.dummy_func)


### PR DESCRIPTION
`# type: ignore` 是最後手段了，藉由只忽略我們確定的 error 類型來盡可能所小範圍，因為同一行可能不只有一種 error。

## 如何查看 error code？

給 mypy 加上 show-error-code 這個參數

```bash
mypy /some/file/path --show-error-code
```