### PR TITLE
修復無 tags 的物品在 /items 會產生 Key Error 的問題

### DIFF
--- a/backend/item/route.py
+++ b/backend/item/route.py
@@ -51,7 +51,7 @@ def fetch_all_items():
                     "discount": item.discount,
                     "original": item.original,
                 },
-                "tags": tags_list_dict_by_item_id[item.id],
+                "tags": tags_list_dict_by_item_id.get(item.id, []),
             }
         )
 

--- a/backend/tests/unit_tests/item/test_item.py
+++ b/backend/tests/unit_tests/item/test_item.py
@@ -571,6 +571,43 @@ class TestGetItemsCountByIdRoute:
 
 
 class TestGetItemsRoute:
+    def test_with_empty_tag_item_in_database_should_respond_correct_payload(
+        self, app: Flask, client: FlaskClient
+    ) -> None:
+        item_data: dict[str, Any] = {
+            "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
+            "count": 10,
+            "description": "This is an apple.",
+            "id": 1,
+            "name": "apple",
+            "original": 30,
+            "discount": 25,
+        }
+        excepted_payload: list[dict[str, Any]] = [
+            {
+                "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
+                "count": 10,
+                "description": "This is an apple.",
+                "id": 1,
+                "name": "apple",
+                "price": {
+                    "original": 30,
+                    "discount": 25,
+                },
+                "tags": [],
+            }
+        ]
+        with app.app_context():
+            item = Item(**item_data)
+            db.session.add(item)
+            db.session.commit()
+
+        response: TestResponse = client.get("/items")
+
+        response_payload: dict[str, Any] | None = response.json
+        assert response_payload is not None
+        assert response_payload == excepted_payload
+
     def test_with_route_should_respond_correct_payload(
         self, client: FlaskClient, setup_item: None
     ) -> None:


### PR DESCRIPTION
## What's the problem?

我們發現到，當出現了沒有 tags 的物品，使用 `GET /items` 取得物品列表時，會出現 `KeyError` 的問題。

## The main action of this PR

 - 新增了一個測試資料，用於模擬新增沒有 tags 的物品。
 - 修正成 dict 應確認是否 absent，否則回傳 empty list。

Resolved: #128 