### PR TITLE
在 item/route.py 中補上函式與 route 的回傳型別並重構複雜的邏輯

### DIFF
--- a/backend/item/route.py
+++ b/backend/item/route.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING, Any, Iterable
 
 from flask import Blueprint, make_response, request
 from pydantic import ValidationError
-from sqlalchemy.engine.row import Row
-from sqlalchemy.sql.expression import Delete, Select
 
 from auth.util import verify_login_or_return_401
 from database import db
@@ -16,6 +14,8 @@ from util import fetch_page, make_single_message_response, route_with_doc
 
 if TYPE_CHECKING:
     from flask import Response
+    from sqlalchemy.engine.row import Row
+    from sqlalchemy.sql.expression import Delete, Select
 
 item_bp = Blueprint("item", __name__)
 

--- a/backend/item/route.py
+++ b/backend/item/route.py
@@ -143,9 +143,8 @@ def update_specific_item(id):
             "The data has the wrong format and the server can't understand it.",
         )
 
-    # Since flatten_item_payload require ALL the field have present.
-    # So we need to flat the specific field to complete the flattern action.
-    # Flat the price dict, since only price need to flat.
+    # Since `flatten_item_payload` requires all the fields to be present as a one level dict,
+    # we have to flatten some fields first.
     if "price" in payload:
         if "original" in payload["price"]:
             payload["original"] = payload["price"]["original"]

--- a/backend/item/route.py
+++ b/backend/item/route.py
@@ -104,7 +104,7 @@ def add_item() -> Response:
 
 @route_with_doc(item_bp, "/items/<string:id>", methods=["GET"])
 def fetch_specific_item(id) -> Response:
-    item: Item | None = db.session.get(Item, id)
+    item: Item | None = db.session.get(Item, id)  # type: ignore[attr-defined]
 
     if item is None:
         return make_single_message_response(
@@ -131,7 +131,7 @@ def fetch_specific_item(id) -> Response:
 @route_with_doc(item_bp, "/items/<string:id>", methods=["PUT"])
 @verify_login_or_return_401
 def update_specific_item(id) -> Response:
-    item: Item | None = db.session.get(Item, id)
+    item: Item | None = db.session.get(Item, id)  # type: ignore[attr-defined]
     payload: dict[str, Any] | None = request.get_json(silent=True)
 
     if item is None:
@@ -199,7 +199,7 @@ def update_specific_item(id) -> Response:
 @route_with_doc(item_bp, "/items/<string:id>", methods=["DELETE"])
 @verify_login_or_return_401
 def delete_specific_item(id) -> Response:
-    item: Item | None = db.session.get(Item, id)
+    item: Item | None = db.session.get(Item, id)  # type: ignore[attr-defined]
 
     if item is None:
         return make_single_message_response(
@@ -214,7 +214,7 @@ def delete_specific_item(id) -> Response:
 
 @route_with_doc(item_bp, "/items/<string:id>/count", methods=["GET"])
 def fetch_count_of_specific_item(id) -> Response:
-    item: Item | None = db.session.get(Item, id)
+    item: Item | None = db.session.get(Item, id)  # type: ignore[attr-defined]
 
     if item is None:
         return make_single_message_response(

--- a/backend/item/route.py
+++ b/backend/item/route.py
@@ -63,7 +63,7 @@ def _map_item_id_to_tags(tags_of_item: list[Row]) -> dict[int, list[dict[str, An
 
 @route_with_doc(item_bp, "/items", methods=["POST"])
 @verify_login_or_return_401
-def add_item():
+def add_item() -> Response:
     payload: dict[str, Any] | None = request.get_json(silent=True)
 
     if payload is None or "name" not in payload:
@@ -94,7 +94,7 @@ def add_item():
     db.session.add(item)
     db.session.flush()
 
-    item_id = item.id
+    item_id: int = item.id
     for tag_id in tag_ids:
         db.session.add(TagOfItem(item_id=item_id, tag_id=tag_id))
 
@@ -103,7 +103,7 @@ def add_item():
 
 
 @route_with_doc(item_bp, "/items/<string:id>", methods=["GET"])
-def fetch_specific_item(id):
+def fetch_specific_item(id) -> Response:
     item: Item | None = db.session.get(Item, id)
 
     if item is None:
@@ -125,13 +125,12 @@ def fetch_specific_item(id):
         },
         "tags": tags,
     }
-
     return make_response(item_with_tags_data)
 
 
 @route_with_doc(item_bp, "/items/<string:id>", methods=["PUT"])
 @verify_login_or_return_401
-def update_specific_item(id):
+def update_specific_item(id) -> Response:
     item: Item | None = db.session.get(Item, id)
     payload: dict[str, Any] | None = request.get_json(silent=True)
 
@@ -199,7 +198,7 @@ def update_specific_item(id):
 
 @route_with_doc(item_bp, "/items/<string:id>", methods=["DELETE"])
 @verify_login_or_return_401
-def delete_specific_item(id):
+def delete_specific_item(id) -> Response:
     item: Item | None = db.session.get(Item, id)
 
     if item is None:
@@ -214,7 +213,7 @@ def delete_specific_item(id):
 
 
 @route_with_doc(item_bp, "/items/<string:id>/count", methods=["GET"])
-def fetch_count_of_specific_item(id):
+def fetch_count_of_specific_item(id) -> Response:
     item: Item | None = db.session.get(Item, id)
 
     if item is None:
@@ -226,13 +225,13 @@ def fetch_count_of_specific_item(id):
 
 
 @route_with_doc(item_bp, "/items_list/<string:id>", methods=["GET"])
-def item_page(id: str):
+def item_page(id: str) -> str:
     # id is intentionally ignored. Backend does not have to handle.
     return fetch_page("item_detail")
 
 
 @route_with_doc(item_bp, "/items_list", methods=["GET"])
-def item_list_page():
+def item_list_page() -> str:
     return fetch_page("item_list")
 
 
@@ -252,7 +251,7 @@ def _fetch_item_tags_list_from_item_id(id: int) -> list[dict[str, Any]]:
     return tags_dict_list
 
 
-def _setup_tags_relationship_of_item(item_id: int, tags_id_list: list[int]):
+def _setup_tags_relationship_of_item(item_id: int, tags_id_list: list[int]) -> None:
     # Step 1. Drop all tags of item if exists.
     delete_tags_stmts: Delete = db.delete(TagOfItem).where(TagOfItem.item_id == item_id)
     db.session.execute(delete_tags_stmts)

--- a/backend/item/util.py
+++ b/backend/item/util.py
@@ -1,7 +1,13 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import StrictInt, StrictStr, Field
-from pydantic.dataclasses import dataclass
+
+if TYPE_CHECKING:
+    from dataclasses import dataclass
+else:
+    # Fixes "Unexpected keyword argument" for custom dataclasses.
+    # See https://github.com/python/mypy/issues/6239.
+    from pydantic.dataclasses import dataclass
 
 
 class PayloadTypeChecker:


### PR DESCRIPTION
## What's changed?

在 #116 中我們實作了 /items 的介面，但遺漏了 type hints。
在這個 PR 中，補上了回傳值的型別以及部分的變數型別，並且針對較複雜的邏輯進行函式提取（extract function）以及簡化 python 的語法。