### PR TITLE
Format code and refactor syntax

### DIFF
--- a/backend/tests/unit_tests/auth/test_auth.py
+++ b/backend/tests/unit_tests/auth/test_auth.py
@@ -120,8 +120,7 @@ class TestLoginRoute:
         }
 
     def test_get_should_response_content_of_login_html(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         resp: TestResponse = client.get("/login")
 
@@ -169,8 +168,7 @@ class TestLoginRoute:
         )
 
     def test_post_with_invalid_data_should_have_code_bad_request(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         invalid_data: dict[str, str] = {"uriah": "garbage"}
 
@@ -179,8 +177,7 @@ class TestLoginRoute:
         assert resp.status_code == HTTPStatus.BAD_REQUEST
 
     def test_post_with_invalid_data_should_response_failed_message_in_json(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         invalid_data: dict[str, str] = {"uriah": "garbage"}
 
@@ -194,8 +191,7 @@ class TestLoginRoute:
         )
 
     def test_post_with_invalid_email_should_have_code_unprocessable_entity(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         invalid_email: str = "t109590031@ntut@org@tw"
         data: dict[str, str] = {"e-mail": invalid_email, "password": "12345678"}
@@ -205,8 +201,7 @@ class TestLoginRoute:
         assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
     def test_post_with_invalid_email_should_response_failed_message_in_json(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         invalid_email: str = "t109590031@ntut@org@tw"
         data: dict[str, str] = {"e-mail": invalid_email, "password": "12345678"}
@@ -221,9 +216,7 @@ class TestLoginRoute:
         )
 
     def test_post_with_existing_email_and_password_should_exist_jwt_cookie(
-        self,
-        client: FlaskClient,
-        new_data: dict[str, Any],
+        self, client: FlaskClient, new_data: dict[str, Any]
     ) -> None:
         client.post("/login", json=new_data)
 
@@ -232,10 +225,7 @@ class TestLoginRoute:
             (jwt_cookie,) = tuple(filter(lambda x: x.name == "jwt", cookies))
 
     def test_post_with_correct_data_should_have_correct_jwt_token_attribute(
-        self,
-        app: Flask,
-        client: FlaskClient,
-        new_data: dict[str, Any],
+        self, app: Flask, client: FlaskClient, new_data: dict[str, Any]
     ) -> None:
         codec = HS256JWTCodec(app.config["jwt_key"])
 
@@ -265,10 +255,7 @@ class TestVerifyJWT:
         }
 
     def test_post_with_valid_jwt_cookie_should_have_code_http_ok(
-        self,
-        app: Flask,
-        client: FlaskClient,
-        payload: dict[str, Any],
+        self, app: Flask, client: FlaskClient, payload: dict[str, Any]
     ) -> None:
         jwt_token: str = HS256JWTCodec(app.config["jwt_key"]).encode(payload)
         client.set_cookie("localhost", "jwt", jwt_token)
@@ -278,10 +265,7 @@ class TestVerifyJWT:
         assert resp.status_code == HTTPStatus.OK
 
     def test_post_with_valid_jwt_cookie_should_return_payload_in_json(
-        self,
-        app: Flask,
-        client: FlaskClient,
-        payload: dict[str, Any],
+        self, app: Flask, client: FlaskClient, payload: dict[str, Any]
     ) -> None:
         jwt_token: str = HS256JWTCodec(app.config["jwt_key"]).encode(payload)
         client.set_cookie("localhost", "jwt", jwt_token)
@@ -292,16 +276,14 @@ class TestVerifyJWT:
         assert resp.json["data"] == payload  # type: ignore[index]
 
     def test_post_with_absent_jwt_cookie_should_have_code_http_unauthorized(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         resp: TestResponse = client.post("/verify_jwt")
 
         assert resp.status_code == HTTPStatus.UNAUTHORIZED
 
     def test_post_with_absent_jwt_cookie_should_return_failed_message_in_json(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         resp: TestResponse = client.post("/verify_jwt")
 
@@ -312,8 +294,7 @@ class TestVerifyJWT:
         )
 
     def test_post_with_invalid_jwt_cookie_should_have_code_http_unprocessable_entity(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         client.set_cookie("localhost", "jwt", "aaa.bbb.ccc")
 
@@ -322,8 +303,7 @@ class TestVerifyJWT:
         assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
     def test_post_with_invalid_jwt_cookie_should_return_failed_message_in_json(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         client.set_cookie("localhost", "jwt", "aaa.bbb.ccc")
 
@@ -337,10 +317,7 @@ class TestVerifyJWT:
 
 
 class TestLogoutRoute:
-    def test_if_jwt_exist_should_return_ok(
-        self,
-        client: FlaskClient,
-    ) -> None:
+    def test_if_jwt_exist_should_return_ok(self, client: FlaskClient) -> None:
         client.set_cookie("localhost", "jwt", "aaa.bbb.ccc")
 
         resp: TestResponse = client.post("/logout")
@@ -348,8 +325,7 @@ class TestLogoutRoute:
         assert resp.status_code == HTTPStatus.OK
 
     def test_if_jwt_exist_should_let_jwt_token_absent(
-        self,
-        client: FlaskClient,
+        self, client: FlaskClient
     ) -> None:
         client.set_cookie("localhost", "jwt", "aaa.bbb.ccc")
 
@@ -358,10 +334,7 @@ class TestLogoutRoute:
         cookies: tuple[Cookie, ...] = _get_cookies(client.cookie_jar)
         assert not cookies
 
-    def test_if_jwt_absent_should_return_ok(
-        self,
-        client: FlaskClient,
-    ) -> None:
+    def test_if_jwt_absent_should_return_ok(self, client: FlaskClient) -> None:
         resp: TestResponse = client.post("/logout")
 
         assert resp.status_code == HTTPStatus.OK

--- a/backend/tests/unit_tests/auth/test_util.py
+++ b/backend/tests/unit_tests/auth/test_util.py
@@ -69,8 +69,7 @@ class TestIsValidBirthday:
         argvalues=("2000/01/01", "2000_01_01", "01-01-2000", "2000.01.01", "20000101"),
     )
     def test_on_incorrect_format_should_return_false(
-        self,
-        birthday_in_incorrect_format: str,
+        self, birthday_in_incorrect_format: str
     ) -> None:
         assert not is_valid_birthday(birthday_in_incorrect_format)
 
@@ -87,10 +86,7 @@ class TestIsValidBirthday:
             "2000/01/32",  # bad day
         ),
     )
-    def test_on_bad_birthday_value_should_return_false(
-        self,
-        bad_birthday: str,
-    ) -> None:
+    def test_on_bad_birthday_value_should_return_false(self, bad_birthday: str) -> None:
         assert not is_valid_birthday(bad_birthday)
 
 
@@ -197,8 +193,7 @@ class TestHS256JWTCodec:
 
     class TestIsValidJWT:
         def test_on_token_with_not_enough_segment_should_return_false(
-            self,
-            codec: HS256JWTCodec,
+            self, codec: HS256JWTCodec
         ) -> None:
             token: str = "should_have_three_dot_separated_segments"
 

--- a/backend/tests/unit_tests/auth/test_util.py
+++ b/backend/tests/unit_tests/auth/test_util.py
@@ -32,31 +32,31 @@ if TYPE_CHECKING:
 class TestIsValidEmail:
     _some_invalid_emails: ClassVar[list[str]] = ["plainaddress", "#@%^%#$@#$@#.com", "@example.com", "Joe Smith <email@example.com>", "email.example.com", "email@example@example.com", ".email@example.com", "email..email@example.com", "email@example.com (Joe Smith)", "email@example", "email@-example.com", "email@111.222.333.44444", "email@example..com", "Abc..123@example.com"]  # fmt: skip
     @pytest.mark.parametrize(
-        argnames=("malformed_email",),
+        argnames="malformed_email",
         argvalues=(
-            ("noletterafterdash-@email.com",),
-            ("badsymbolindomain@ema#il.com",),
-            ("multipleat@email@org.tw",),
-            ("badsymbol#123@email.com",),
-            (".startwithdot@email.com",),
-            ("double..dot@email.com",),
-            ("domainwithnodot@email",),
-            ("missingat.email.com",),
-            ("あいうえお@example.com",),
-            *((invalid_email,) for invalid_email in _some_invalid_emails),
+            "noletterafterdash-@email.com",
+            "badsymbolindomain@ema#il.com",
+            "multipleat@email@org.tw",
+            "badsymbol#123@email.com",
+            ".startwithdot@email.com",
+            "double..dot@email.com",
+            "domainwithnodot@email",
+            "missingat.email.com",
+            "あいうえお@example.com",
+            *(invalid_email for invalid_email in _some_invalid_emails),
         ),
     )
     def test_on_malformed_email_should_return_false(self, malformed_email: str) -> None:
         assert not is_valid_email(malformed_email)
 
     @pytest.mark.parametrize(
-        argnames=("email",),
+        argnames="email",
         argvalues=(
-            ("letterafterdash-123@email.com",),
-            ("dot.in.middle@email.com",),
-            ("under_score@email.com",),
-            ("CAPTIAL@email.com",),
-            ("123@email.com",),
+            "letterafterdash-123@email.com",
+            "dot.in.middle@email.com",
+            "under_score@email.com",
+            "CAPTIAL@email.com",
+            "123@email.com",
         ),
     )
     def test_on_valid_email_should_return_true(self, email: str) -> None:
@@ -65,14 +65,8 @@ class TestIsValidEmail:
 
 class TestIsValidBirthday:
     @pytest.mark.parametrize(
-        argnames=("birthday_in_incorrect_format",),
-        argvalues=(
-            ("2000/01/01",),
-            ("2000_01_01",),
-            ("01-01-2000",),
-            ("2000.01.01",),
-            ("20000101",),
-        ),
+        argnames="birthday_in_incorrect_format",
+        argvalues=("2000/01/01", "2000_01_01", "01-01-2000", "2000.01.01", "20000101"),
     )
     def test_on_incorrect_format_should_return_false(
         self,
@@ -86,11 +80,11 @@ class TestIsValidBirthday:
         assert is_valid_birthday(birthday)
 
     @pytest.mark.parametrize(
-        argnames=("bad_birthday",),
+        argnames="bad_birthday",
         argvalues=(
-            ("2000/13/01",),  # bad month
-            ("-1/01/01",),  # bad year
-            ("2000/01/32",),  # bad day
+            "2000/13/01",  # bad month
+            "-1/01/01",  # bad year
+            "2000/01/32",  # bad day
         ),
     )
     def test_on_bad_birthday_value_should_return_false(

--- a/backend/tests/unit_tests/item/test_item.py
+++ b/backend/tests/unit_tests/item/test_item.py
@@ -30,7 +30,7 @@ def test_get_items_list_should_respond_content_of_item_list_html(
     assert b"item_list.html (a marker for API test)" in response.data
 
 
-@pytest.mark.parametrize(argnames=("item_id",), argvalues=(("1",), ("10",), ("99",)))
+@pytest.mark.parametrize(argnames="item_id", argvalues=("1", "10", "99"))
 def test_get_items_list_by_id_with_any_id_should_respond_content_of_item_detail_html(
     client: FlaskClient, item_id: str
 ) -> None:

--- a/backend/tests/unit_tests/item/test_item.py
+++ b/backend/tests/unit_tests/item/test_item.py
@@ -236,30 +236,36 @@ class TestGetItemsByIdRoute:
 
 
 class TestPutItemsByIdRoute:
-    def compare_item_and_excepted_item_payload_is_equal(
-        self, app: Flask, item_id: int, expected_item_payload: dict[str, Any]
+    def has_equal_item_and_excepted_item_payload(
+        self, item_id: int, expected_item_payload: dict[str, Any]
     ) -> bool:
-        with app.app_context():
-            item: Item = db.session.get(Item, item_id)  # type: ignore[attr-defined]
-            tags: list[TagOfItem] = db.session.execute(
+        """
+        Has to be called with the app context.
+
+        Args:
+            item_id: the id of the item to be compared.
+            expected_item_payload: the payload which indicates the expected field values.
+        """
+        item: Item = db.session.get(Item, item_id)  # type: ignore[attr-defined]
+        tag_ids: list[int] = (
+            db.session.execute(
                 db.select(TagOfItem.tag_id).where(TagOfItem.item_id == item_id)
             )
+            .scalars()
+            .all()
+        )
+        tag_ids_from_excepted_item_payload: list[int] = [
+            tag["id"] for tag in expected_item_payload["tags"]
+        ]
 
-            tag_ids_list_from_query: list[int] = sorted([tag.tag_id for tag in tags])
-            tag_ids_list_from_excepted_item_payload: list[int] = sorted(
-                [tag_dict["id"] for tag_dict in expected_item_payload["tags"]]
-            )
-
-            check_result: bool = True
-            check_result &= item.avatar == expected_item_payload["avatar"]
-            check_result &= item.count == expected_item_payload["count"]
-            check_result &= item.name == expected_item_payload["name"]
-            check_result &= item.original == expected_item_payload["price"]["original"]
-            check_result &= item.discount == expected_item_payload["price"]["discount"]
-            check_result &= (
-                tag_ids_list_from_query == tag_ids_list_from_excepted_item_payload
-            )
-            return check_result
+        return (
+            item.avatar == expected_item_payload["avatar"]
+            and item.count == expected_item_payload["count"]
+            and item.name == expected_item_payload["name"]
+            and item.original == expected_item_payload["price"]["original"]
+            and item.discount == expected_item_payload["price"]["discount"]
+            and sorted(tag_ids) == sorted(tag_ids_from_excepted_item_payload)
+        )
 
     def test_with_correct_payload_should_update_item_to_database(
         self, app: Flask, logged_in_client: FlaskClient, setup_item: None
@@ -287,9 +293,10 @@ class TestPutItemsByIdRoute:
         )
 
         assert response.status_code == HTTPStatus.OK
-        assert self.compare_item_and_excepted_item_payload_is_equal(
-            app, 1, expected_item_payload
-        )
+        with app.app_context():
+            assert self.has_equal_item_and_excepted_item_payload(
+                1, expected_item_payload
+            )
 
     def test_with_only_price_payload_should_update_item_to_database(
         self, app: Flask, logged_in_client: FlaskClient, setup_item: None
@@ -312,9 +319,10 @@ class TestPutItemsByIdRoute:
         )
 
         assert response.status_code == HTTPStatus.OK
-        assert self.compare_item_and_excepted_item_payload_is_equal(
-            app, 1, expected_item_payload
-        )
+        with app.app_context():
+            assert self.has_equal_item_and_excepted_item_payload(
+                1, expected_item_payload
+            )
 
     def test_with_only_original_price_payload_should_update_item_to_database(
         self, app: Flask, logged_in_client: FlaskClient, setup_item: None
@@ -337,9 +345,10 @@ class TestPutItemsByIdRoute:
         )
 
         assert response.status_code == HTTPStatus.OK
-        assert self.compare_item_and_excepted_item_payload_is_equal(
-            app, 1, expected_item_payload
-        )
+        with app.app_context():
+            assert self.has_equal_item_and_excepted_item_payload(
+                1, expected_item_payload
+            )
 
     def test_with_only_discount_price_payload_should_update_item_to_database(
         self, app: Flask, logged_in_client: FlaskClient, setup_item: None
@@ -362,9 +371,10 @@ class TestPutItemsByIdRoute:
         )
 
         assert response.status_code == HTTPStatus.OK
-        assert self.compare_item_and_excepted_item_payload_is_equal(
-            app, 1, expected_item_payload
-        )
+        with app.app_context():
+            assert self.has_equal_item_and_excepted_item_payload(
+                1, expected_item_payload
+            )
 
     def test_with_only_tag_payload_should_update_item_to_database(
         self, app: Flask, logged_in_client: FlaskClient, setup_item: None
@@ -387,9 +397,10 @@ class TestPutItemsByIdRoute:
         )
 
         assert response.status_code == HTTPStatus.OK
-        assert self.compare_item_and_excepted_item_payload_is_equal(
-            app, 1, expected_item_payload
-        )
+        with app.app_context():
+            assert self.has_equal_item_and_excepted_item_payload(
+                1, expected_item_payload
+            )
 
     def test_with_wrong_content_type_payload_should_return_http_status_code_bad_request(
         self, logged_in_client: FlaskClient, setup_item: None

--- a/backend/tests/unit_tests/static/test_util.py
+++ b/backend/tests/unit_tests/static/test_util.py
@@ -108,15 +108,13 @@ def test_verify_image_with_invalid_data_should_return_false() -> None:
 
 
 @pytest.mark.parametrize(
-    argnames=("bad_uuid",),
+    argnames="bad_uuid",
     argvalues=(
-        ("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE-",),  # Redundant dash in back of string
-        ("-AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",),  # Redundant dash in front of uuid
-        ("A-B-C-D-E",),  # Not enough length in every segment
-        ("A-B-C",),  # Not enough segment
-        (
-            "________-____-____-____-____________",
-        ),  # Correct length of segment but invalid character.
+        "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE-",  # Redundant dash in back of string
+        "-AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",  # Redundant dash in front of uuid
+        "A-B-C-D-E",  # Not enough length in every segment
+        "A-B-C",  # Not enough segment
+        "________-____-____-____-____________",  # Correct length of segment but invalid character.
     ),
 )
 def test_verify_uuid_with_invalid_data_should_return_false(bad_uuid: str) -> None:

--- a/backend/tests/unit_tests/tag/test_tag.py
+++ b/backend/tests/unit_tests/tag/test_tag.py
@@ -73,10 +73,10 @@ class TestPostTagsRoute:
         assert tag is not None
 
     @pytest.mark.parametrize(
-        argnames=("payload",),
+        argnames="payload",
         argvalues=(
-            (None,),  # missing payload
-            ({"should be name": "xxx"},),  # missing key "name"
+            None,  # missing payload
+            {"should be name": "xxx"},  # missing key "name"
         ),
     )
     def test_with_wrong_data_format_should_respond_bad_request_with_message(
@@ -229,10 +229,10 @@ class TestPutTagsByIdRoute:
         assert response.get_json(silent=True) == {"message": "Unauthorized."}
 
     @pytest.mark.parametrize(
-        argnames=("payload",),
+        argnames="payload",
         argvalues=(
-            (None,),  # missing payload
-            ({"should be name": "xxx"},),  # missing key "name"
+            None,  # missing payload
+            {"should be name": "xxx"},  # missing key "name"
         ),
     )
     def test_with_wrong_data_format_should_respond_bad_request_with_message(

--- a/backend/tests/unit_tests/test_util.py
+++ b/backend/tests/unit_tests/test_util.py
@@ -33,9 +33,7 @@ class TestSingleMessageStatus:
 
         assert status.message == {"message": "page returned"}
 
-    @pytest.mark.parametrize(
-        argnames=("status_code",), argvalues=((102,), (226,), (308,))
-    )
+    @pytest.mark.parametrize(argnames="status_code", argvalues=(102, 226, 308))
     def test_default_message_on_not_error_status_code_should_be_ok(
         self, status_code: int
     ) -> None:


### PR DESCRIPTION
## What's changed?

這個 PR 是一個針對單元測試的重構，包含了以下 3 點：

- 針對測試中參數列的換行規則進行調整
  - 移除了 trailing comma 讓 black 不會強制換行
- 簡化 `pytest.mark.parametrize` 處理單個參數時的語法
  - 只有在多參數時才需要用 tuple 包裝
- 簡化了一個使用邏輯運算子（&）的 util 函式，並且重新命名變數
  - 不傳入 `app` 因為那個參數的出現會模糊 util 的作用