### PR TITLE
Create models of shopping_cart, order and item_of_order

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -98,8 +98,12 @@ class Order(db.Model):  # type: ignore[name-defined]
         db.ForeignKey(User.uid, ondelete="CASCADE", onupdate="CASCADE"), nullable=False
     )
     date = db.Column(db.Integer, nullable=False)
-    order_status = db.Column(db.Enum(OrderStatus), nullable=False)
-    delivery_status = db.Column(db.Enum(DeliveryStatus), nullable=False)
+    order_status = db.Column(
+        db.Enum(OrderStatus, validate_strings=True), nullable=False
+    )
+    delivery_status = db.Column(
+        db.Enum(DeliveryStatus, validate_strings=True), nullable=False
+    )
     delivery_address = db.Column(db.Text, nullable=False)
     note = db.Column(db.Text)
     phone = db.Column(db.String(10), nullable=False)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -94,7 +94,9 @@ class DeliveryStatus(enum.Enum):
 
 class Order(db.Model):  # type: ignore[name-defined]
     order_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    user_id = db.Column(db.ForeignKey(User.uid, ondelete="CASCADE", onupdate="CASCADE"))
+    user_id = db.Column(
+        db.ForeignKey(User.uid, ondelete="CASCADE", onupdate="CASCADE"), nullable=False
+    )
     date = db.Column(db.Integer, nullable=False)
     order_status = db.Column(db.Enum(OrderStatus), nullable=False)
     delivery_status = db.Column(db.Enum(DeliveryStatus), nullable=False)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,3 +1,5 @@
+import enum
+
 from database import db
 
 
@@ -64,6 +66,48 @@ class TagOfItem(db.Model):  # type: ignore[name-defined]
 class ShoppingCart(db.Model):  # type: ignore[name-defined]
     user_id = db.Column(
         db.ForeignKey(User.uid, ondelete="CASCADE", onupdate="CASCADE"),
+        primary_key=True,
+    )
+    item_id = db.Column(
+        db.ForeignKey(Item.id, ondelete="CASCADE", onupdate="CASCADE"),
+        primary_key=True,
+    )
+    count = db.Column(db.Integer, nullable=False)
+
+    __table_args__ = (db.CheckConstraint(count > 0),)
+
+
+@enum.unique
+class OrderStatus(enum.Enum):
+    CANCEL = enum.auto()
+    CHECKING = enum.auto()
+    OK = enum.auto()
+
+
+@enum.unique
+class DeliveryStatus(enum.Enum):
+    DELIVERED = enum.auto()
+    DELIVERING = enum.auto()
+    PENDING = enum.auto()
+    SKIP = enum.auto()
+
+
+class Order(db.Model):  # type: ignore[name-defined]
+    order_id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user_id = db.Column(db.ForeignKey(User.uid, ondelete="CASCADE", onupdate="CASCADE"))
+    date = db.Column(db.Integer, nullable=False)
+    order_status = db.Column(db.Enum(OrderStatus), nullable=False)
+    delivery_status = db.Column(db.Enum(DeliveryStatus), nullable=False)
+    delivery_address = db.Column(db.Text, nullable=False)
+    note = db.Column(db.Text)
+    phone = db.Column(db.String(10), nullable=False)
+
+
+class ItemOfOrder(db.Model):  # type: ignore[name-defined]
+    """The records in the ShoppingCart are moved to this table when a new order is made from the cart."""
+
+    order_id = db.Column(
+        db.ForeignKey(Order.order_id, ondelete="CASCADE", onupdate="CASCADE"),
         primary_key=True,
     )
     item_id = db.Column(

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -59,3 +59,17 @@ class TagOfItem(db.Model):  # type: ignore[name-defined]
         ),
         primary_key=True,
     )
+
+
+class ShoppingCart(db.Model):  # type: ignore[name-defined]
+    user_id = db.Column(
+        db.ForeignKey(User.uid, ondelete="CASCADE", onupdate="CASCADE"),
+        primary_key=True,
+    )
+    item_id = db.Column(
+        db.ForeignKey(Item.id, ondelete="CASCADE", onupdate="CASCADE"),
+        primary_key=True,
+    )
+    count = db.Column(db.Integer, nullable=False)
+
+    __table_args__ = (db.CheckConstraint(count > 0),)

--- a/backend/tests/integration_tests/test_model.py
+++ b/backend/tests/integration_tests/test_model.py
@@ -1,7 +1,19 @@
-from tests.unit_tests.models.test_model import TestCascadeUpdateAndDeleteOnTagOfItem
+from tests.unit_tests.models.test_model import (
+    TestCascadeUpdateAndDeleteOnTagOfItem,
+    TestItemOfOrder,
+    TestOrder,
+)
 
 
 class TestCascadeUpdateAndDeleteOnTagOfItemWithMariaDB(
     TestCascadeUpdateAndDeleteOnTagOfItem
 ):
+    pass
+
+
+class TestOrderWithMariaDB(TestOrder):
+    pass
+
+
+class TestItemOfOrderWithMariaDB(TestItemOfOrder):
     pass

--- a/backend/tests/integration_tests/test_model.py
+++ b/backend/tests/integration_tests/test_model.py
@@ -2,12 +2,17 @@ from tests.unit_tests.models.test_model import (
     TestCascadeUpdateAndDeleteOnTagOfItem,
     TestItemOfOrder,
     TestOrder,
+    TestShoppingCart,
 )
 
 
 class TestCascadeUpdateAndDeleteOnTagOfItemWithMariaDB(
     TestCascadeUpdateAndDeleteOnTagOfItem
 ):
+    pass
+
+
+class TestShoppingCartWithMariaDB(TestShoppingCart):
     pass
 
 

--- a/backend/tests/unit_tests/models/test_model.py
+++ b/backend/tests/unit_tests/models/test_model.py
@@ -180,6 +180,9 @@ class TestShoppingCart:
     def test_with_non_positive_item_count_should_throw_exception(
         self, app: Flask, non_positive_item_count: int
     ) -> None:
+        # Since different databases may raise different type of errors,
+        # e.g., SQLite raises IntegrityError while MariaDB raises OperationalError,
+        # we catch their base type.
         with app.app_context(), pytest.raises(DatabaseError):
             db.session.add(
                 ShoppingCart(count=non_positive_item_count, user_id=1, item_id=1)
@@ -216,6 +219,7 @@ class TestOrder:
 class TestItemOfOrder:
     def insert_test_data(self, app: Flask) -> None:
         with app.app_context():
+            # The only thing we have to know is their ids, so prevent formatting which spans multiple lines.
             # fmt: off
             db.session.add(Item(id=1, name="apple", count=10, description="This is an apple.", original=30, discount=25, avatar="xx-S0m3-aVA7aR-0f-a991e-xx"))
             db.session.add(Order(order_id=1, user_id=1, order_status=OrderStatus.OK, delivery_status=DeliveryStatus.DELIVERED, date=1000000,
@@ -227,9 +231,6 @@ class TestItemOfOrder:
     def test_with_non_positive_item_count_should_throw_exception(
         self, app: Flask, non_positive_item_count: int
     ) -> None:
-        # Since different databases may raise different type of errors,
-        # e.g., SQLite raises IntegrityError while MariaDB raises OperationalError),
-        # we catch their base type.
         with app.app_context(), pytest.raises(DatabaseError):
             db.session.add(
                 ItemOfOrder(count=non_positive_item_count, item_id=1, order_id=1)

--- a/backend/tests/unit_tests/models/test_model.py
+++ b/backend/tests/unit_tests/models/test_model.py
@@ -212,8 +212,8 @@ class TestOrder:
         with app.app_context():
             order: Order | None = db.session.get(Order, 1)  # type: ignore[attr-defined]
             assert order is not None
-            assert order.order_status == order_status
-            assert order.delivery_status == delivery_status
+            assert order.order_status is order_status
+            assert order.delivery_status is delivery_status
 
 
 class TestItemOfOrder:


### PR DESCRIPTION
## What's new?

新增了 3 個 table，分別是 `shopping_cart`, `order` 和 `item_of_order`。

### SQL statements

這些 table 是用 SQLAlchemy 的 interface 建立的，實際執行轉換成 MariaDB 的 SQL 後有以下敘述：

```sql
CREATE TABLE shopping_cart (
    user_id INTEGER NOT NULL, 
    item_id INTEGER NOT NULL, 
    count INTEGER NOT NULL, 
    PRIMARY KEY (user_id, item_id), 
    CHECK (count > 0), 
    FOREIGN KEY(user_id) REFERENCES user (uid) ON DELETE CASCADE ON UPDATE CASCADE, 
    FOREIGN KEY(item_id) REFERENCES item (id) ON DELETE CASCADE ON UPDATE CASCADE
)

CREATE TABLE `order` (
    order_id INTEGER NOT NULL AUTO_INCREMENT, 
    user_id INTEGER NOT NULL, 
    date INTEGER NOT NULL, 
    order_status ENUM('CANCEL','CHECKING','OK') NOT NULL, 
    delivery_status ENUM('DELIVERED','DELIVERING','PENDING','SKIP') NOT NULL, 
    delivery_address TEXT NOT NULL, 
    note TEXT, 
    phone VARCHAR(10) NOT NULL, 
    PRIMARY KEY (order_id), 
    FOREIGN KEY(user_id) REFERENCES user (uid) ON DELETE CASCADE ON UPDATE CASCADE
)

CREATE TABLE item_of_order (
    order_id INTEGER NOT NULL, 
    item_id INTEGER NOT NULL, 
    count INTEGER NOT NULL, 
    PRIMARY KEY (order_id, item_id), 
    CHECK (count > 0), 
    FOREIGN KEY(order_id) REFERENCES `order` (order_id) ON DELETE CASCADE ON UPDATE CASCADE, 
    FOREIGN KEY(item_id) REFERENCES item (id) ON DELETE CASCADE ON UPDATE CASCADE
)
```
`order_status` 和 `delivery_status` 兩個欄位背後有 Python 的 `Enum`, SQLALchemy 會自動進行轉換。

### Tables

table 建立後於 MariaDB 中 `DESCRIBE` 的樣子如下：

```
shopping_cart
+---------+---------+------+-----+---------+-------+
| Field   | Type    | Null | Key | Default | Extra |
+---------+---------+------+-----+---------+-------+
| user_id | int(11) | NO   | PRI | NULL    |       |
| item_id | int(11) | NO   | PRI | NULL    |       |
| count   | int(11) | NO   |     | NULL    |       |
+---------+---------+------+-----+---------+-------+

`order`
+------------------+-------------------------------------------------+------+-----+---------+----------------+
| Field            | Type                                            | Null | Key | Default | Extra          |
+------------------+-------------------------------------------------+------+-----+---------+----------------+
| order_id         | int(11)                                         | NO   | PRI | NULL    | auto_increment |
| user_id          | int(11)                                         | NO   | MUL | NULL    |                |
| date             | int(11)                                         | NO   |     | NULL    |                |
| order_status     | enum('CANCEL','CHECKING','OK')                  | NO   |     | NULL    |                |
| delivery_status  | enum('DELIVERED','DELIVERING','PENDING','SKIP') | NO   |     | NULL    |                |
| delivery_address | text                                            | NO   |     | NULL    |                |
| note             | text                                            | YES  |     | NULL    |                |
| phone            | varchar(10)                                     | NO   |     | NULL    |                |
+------------------+-------------------------------------------------+------+-----+---------+----------------+
item_of_order
+----------+---------+------+-----+---------+-------+
| Field    | Type    | Null | Key | Default | Extra |
+----------+---------+------+-----+---------+-------+
| order_id | int(11) | NO   | PRI | NULL    |       |
| item_id  | int(11) | NO   | PRI | NULL    |       |
| count    | int(11) | NO   |     | NULL    |       |
+----------+---------+------+-----+---------+-------+
```

## How has This been tested?

3 組測資針對 `count > 0` 的 check constraint 以及 enum 的轉換去確認，在 SQLite 與 MariaDB 環境下皆通過測試。

- [x] `shopping_cart` 中的 `count` 不為正時會拋例外
- [x] `item_of_order` 中的 `count` 不為正時會拋例外
- [x] `order` 中的 `order_status` 和 `delivery_status` 可使用 `Enum` 新增，查詢出來時也是 `Enum`
- [x] `order` 中的 `order_status` 和 `delivery_status` 若傳入非 `Enum` 定義中的值會拋出 `StatementError` 例外

**NOTE**: 不同的資料庫遇到 check constriant 不符合時所拋出的例外型別可能不同（SQLIte 是 IntegrityError 而 MariaDB 是 OperationalError），因此接例外時接他們的 Base type 來確保能相容。