### PR TITLE
Fix missing fields of the `Ｏrder` table

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -95,6 +95,9 @@ class Order(db.Model):  # type: ignore[name-defined]
         db.Enum(DeliveryStatus, validate_strings=True), nullable=False
     )
     delivery_address = db.Column(db.Text, nullable=False)
+    delivery_firstname = db.Column(db.String(100), nullable=False)
+    delivery_lastname = db.Column(db.String(100), nullable=False)
+    delivery_email = db.Column(db.String(100), nullable=False)
     note = db.Column(db.Text)
     phone = db.Column(db.String(10), nullable=False)
 

--- a/backend/tests/unit_tests/models/test_model.py
+++ b/backend/tests/unit_tests/models/test_model.py
@@ -204,6 +204,9 @@ class TestOrder:
                     user_id=1,
                     date=1000000,
                     delivery_address="No. 1, Sec. 3, Zhongxiao E. Rd., Da'an Dist., Taipei City 106344 , Taiwan (R.O.C.)",
+                    delivery_firstname="Han-Xuan",
+                    delivery_lastname="Huang",
+                    delivery_email="test@test.com",
                     note="xxx",
                     phone="0123456789",
                 )
@@ -230,6 +233,9 @@ class TestOrder:
                     user_id=1,
                     date=1000000,
                     delivery_address="No. 1, Sec. 3, Zhongxiao E. Rd., Da'an Dist., Taipei City 106344 , Taiwan (R.O.C.)",
+                    delivery_firstname="Han-Xuan",
+                    delivery_lastname="Huang",
+                    delivery_email="test@test.com",
                     note="xxx",
                     phone="0123456789",
                 )
@@ -250,6 +256,9 @@ class TestOrder:
                     user_id=1,
                     date=1000000,
                     delivery_address="No. 1, Sec. 3, Zhongxiao E. Rd., Da'an Dist., Taipei City 106344 , Taiwan (R.O.C.)",
+                    delivery_firstname="Han-Xuan",
+                    delivery_lastname="Huang",
+                    delivery_email="test@test.com",
                     note="xxx",
                     phone="0123456789",
                 )
@@ -264,7 +273,8 @@ class TestItemOfOrder:
             # fmt: off
             db.session.add(Item(id=1, name="apple", count=10, description="This is an apple.", original=30, discount=25, avatar="xx-S0m3-aVA7aR-0f-a991e-xx"))
             db.session.add(Order(order_id=1, user_id=1, order_status=OrderStatus.OK, delivery_status=DeliveryStatus.DELIVERED, date=1000000,
-                            delivery_address="No. 1, Sec. 3, Zhongxiao E. Rd., Da'an Dist., Taipei City 106344 , Taiwan (R.O.C.)", note="xxx", phone="0123456789"))
+                            delivery_address="No. 1, Sec. 3, Zhongxiao E. Rd., Da'an Dist., Taipei City 106344 , Taiwan (R.O.C.)", delivery_email="test@test.com",
+                            delivery_firstname="Han-Xuan", delivery_lastname="Huang", note="xxx", phone="0123456789"))
             # fmt: on
             db.session.commit()
 


### PR DESCRIPTION
## What's changed?

在 `Ｏrder` 這個 table 中新增了以下欄位：

- `firstname`
- `lastname`
- `email`

因為使用者在註冊時不一定要用真名，因此下訂時會另外填寫個資，而非藉由 `user_id` 向 `User` table 拿，並且記錄於訂單中。