### PR TITLE
Update apidoc of `POST /orders` on broken payload

### DIFF
--- a/backend/api/order/orders/post.yml
+++ b/backend/api/order/orders/post.yml
@@ -25,6 +25,14 @@ responses:
             type: int
         example:
           id: 5
+  400:
+    description: The data has the wrong format and the server can't understand it.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: The data has the wrong format and the server can't understand it.
   401:
     description: Unauthorized.
     content:
@@ -41,6 +49,14 @@ responses:
           $ref: '#/definitions/message'
         example:
           message: Exists unavailable item in the order.
+  422:
+    description: The posted data has the correct format, but the data is invalid.
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: The posted data has the correct format, but the data is invalid.
 
 definitions:
   order_payload:


### PR DESCRIPTION
對 `POST /orders` 這個操作新增了兩個回應情況：

1. 若沒有給 payload 或欄位錯誤應回傳 `400 Bad Request`
2. 若 payload 內容型別錯誤應回傳 `422 Unprocessable Entity`

Resolves: #162 