### PR TITLE
完成 `route_with_doc` 的修復

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from secrets import token_hex
 from urllib.parse import quote
 
@@ -7,6 +8,7 @@ SQLALCHEMY_DATABASE_URI: str = (
         password=quote("@fsa2022")
     )
 )
+API_DIRECTORY_PATH = str(Path(__file__).parent.resolve(strict=True)) + "/api/"
 STATIC_RESOURCE_PATH = "/var/fastshop/image"
 SWAGGER = {
     "title": "FastShop API",

--- a/backend/tests/unit_tests/test_util.py
+++ b/backend/tests/unit_tests/test_util.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from http import HTTPStatus
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 from flask import Blueprint
 
+from config import API_DIRECTORY_PATH
 from util import SingleMessageStatus, fetch_page, route_with_doc
 
 if TYPE_CHECKING:
@@ -61,7 +63,9 @@ class TestRouteWithDocDecorator:
     def test_should_map_no_param_rule_to_doc_path(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        expect_path = self.ExpectedDocPathFunctor("../api/test/some/rule/get.yml")
+        expect_path = self.ExpectedDocPathFunctor(
+            API_DIRECTORY_PATH + "/test/some/rule/get.yml"
+        )
         monkeypatch.setattr("util.swag_from", expect_path)
 
         route_with_doc(Blueprint("test", __name__), "/some/rule", methods=["GET"])(
@@ -72,7 +76,7 @@ class TestRouteWithDocDecorator:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         expect_path = self.ExpectedDocPathFunctor(
-            "../api/test/some/param1/rule/param2/get.yml"
+            API_DIRECTORY_PATH + "/test/some/param1/rule/param2/get.yml"
         )
         monkeypatch.setattr("util.swag_from", expect_path)
 
@@ -84,7 +88,7 @@ class TestRouteWithDocDecorator:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         expect_path = self.ExpectedDocPathFunctor(
-            "../api/test/some/param1/rule/param2/get.yml"
+            API_DIRECTORY_PATH + "/test/some/param1/rule/param2/get.yml"
         )
         monkeypatch.setattr("util.swag_from", expect_path)
 
@@ -98,7 +102,8 @@ class TestRouteWithDocDecorator:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         expect_path = self.ExpectedDocPathFunctor(
-            "../api/test/some/has_type/rule/no_type/and/has_type/more/no_type/get.yml"
+            API_DIRECTORY_PATH
+            + "/test/some/has_type/rule/no_type/and/has_type/more/no_type/get.yml"
         )
         monkeypatch.setattr("util.swag_from", expect_path)
 
@@ -133,3 +138,9 @@ class TestRouteWithDocDecorator:
         test_bp.route = self.RulePassedToRouteShouldNotChangeFunctor(rule)  # type: ignore[assignment]
 
         route_with_doc(test_bp, rule, methods=["GET"])(self.dummy_func)
+
+
+def test_api_direcotry_should_exists() -> None:
+    is_api_directory_exists = Path(API_DIRECTORY_PATH).exists()
+
+    assert is_api_directory_exists == True

--- a/backend/tests/unit_tests/test_util.py
+++ b/backend/tests/unit_tests/test_util.py
@@ -143,4 +143,4 @@ class TestRouteWithDocDecorator:
 def test_api_direcotry_should_exists() -> None:
     is_api_directory_exists = Path(API_DIRECTORY_PATH).exists()
 
-    assert is_api_directory_exists == True
+    assert is_api_directory_exists

--- a/backend/tests/unit_tests/test_util.py
+++ b/backend/tests/unit_tests/test_util.py
@@ -140,7 +140,7 @@ class TestRouteWithDocDecorator:
         route_with_doc(test_bp, rule, methods=["GET"])(self.dummy_func)
 
 
-def test_api_direcotry_should_exists() -> None:
+def test_api_directory_should_exists() -> None:
     is_api_directory_exists = Path(API_DIRECTORY_PATH).exists()
 
     assert is_api_directory_exists

--- a/backend/util.py
+++ b/backend/util.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 from flasgger import swag_from
 from flask import current_app, make_response
 
+from config import API_DIRECTORY_PATH
+
 if TYPE_CHECKING:
     from http import HTTPStatus
 
@@ -41,7 +43,7 @@ def route_with_doc(bp: Blueprint, rule: str, methods: list[str]):
     def wrapper(func):
         for method in methods:
             swag_from(
-                f"../../api/{bp.name}{doc_path}/{method.lower()}.yml",
+                f"{API_DIRECTORY_PATH}/{bp.name}{doc_path}/{method.lower()}.yml",
                 methods=[method],
             )(func)
         return bp.route(rule, methods=methods)(func)

--- a/backend/util.py
+++ b/backend/util.py
@@ -41,7 +41,7 @@ def route_with_doc(bp: Blueprint, rule: str, methods: list[str]):
     def wrapper(func):
         for method in methods:
             swag_from(
-                f"../api/{bp.name}{doc_path}/{method.lower()}.yml",
+                f"../../api/{bp.name}{doc_path}/{method.lower()}.yml",
                 methods=[method],
             )(func)
         return bp.route(rule, methods=methods)(func)


### PR DESCRIPTION
## Bug

由於更改了檔案架構（#165），所以導致 `route_with_doc` 本身讀取的相對路徑受到問題。

在這個 PR 上，我作了以下修改：

1. 以 backend 絕對路徑來取代相對路徑。
2. 新增確認 api directory 是否存在的測試。
3. 將路徑加入至 `config.py` 上。