### PR TITLE
調整 ShoppingCart 的 documentation

### DIFF
--- a/backend/api/shopping_cart/shopping_cart/get.yml
+++ b/backend/api/shopping_cart/shopping_cart/get.yml
@@ -10,6 +10,14 @@ responses:
       application/json:
         schema:
           $ref: '#/definitions/shopping_cart_response'
+  401:
+    description: Unauthorized.
+    content:
+      application/json:
+        schema:
+          $ref: "#/definitions/message"
+        example:
+          message: Unauthorized.
 
 definitions:
   shopping_cart_response:

--- a/backend/api/shopping_cart/shopping_cart/get.yml
+++ b/backend/api/shopping_cart/shopping_cart/get.yml
@@ -26,7 +26,7 @@ definitions:
       price:
         description: The total price of the shopping cart.
         type: integer
-        example: 200
+        example: 480
       count:
         description: The count of items in the shopping cart.
         type: integer
@@ -42,8 +42,8 @@ definitions:
               type: integer
         example:
         - id: 3
-          price: 4
+          price: 40
           count: 5
         - id: 5
-          price: 4
+          price: 40
           count: 7

--- a/backend/api/shopping_cart/shopping_cart/item/post.yml
+++ b/backend/api/shopping_cart/shopping_cart/item/post.yml
@@ -54,7 +54,7 @@ responses:
     description:
       "The possible situations that cause `403`:\n\n
         - Item with specific ID is already exist in shopping cart. \n\n
-        - Item with specific ID is not exists. \n\n
+        - Item with specific ID is already exists. \n\n
       The route will respond the failed message with respect to the situation."
     content:
       application/json:

--- a/backend/api/shopping_cart/shopping_cart/item/post.yml
+++ b/backend/api/shopping_cart/shopping_cart/item/post.yml
@@ -54,7 +54,7 @@ responses:
     description:
       "The possible situations that cause `403`:\n\n
         - Item with the specific ID already exists in the shopping cart.\n\n
-        - Item with the specific ID already exists.\n\n
+        - Item with the specific ID does not exists.\n\n
       The route will respond the failed message with respect to the situation."
     content:
       application/json:

--- a/backend/api/shopping_cart/shopping_cart/item/post.yml
+++ b/backend/api/shopping_cart/shopping_cart/item/post.yml
@@ -50,6 +50,18 @@ responses:
           $ref: "#/definitions/message"
         example:
           message: Unauthorized.
+  403:
+    description:
+      "The possible situations that cause `403`:\n\n
+        - Item with specific ID is already exist in shopping cart. \n\n
+        - Item with specific ID is not exists. \n\n
+      The route will respond the failed message with respect to the situation."
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/message'
+        example:
+          message: Item with specific ID is already exist in shopping cart.
   422:
     description: The posted data has the correct format, but the data is invalid.
     content:

--- a/backend/api/shopping_cart/shopping_cart/item/post.yml
+++ b/backend/api/shopping_cart/shopping_cart/item/post.yml
@@ -53,15 +53,15 @@ responses:
   403:
     description:
       "The possible situations that cause `403`:\n\n
-        - Item with specific ID is already exist in shopping cart. \n\n
-        - Item with specific ID is already exists. \n\n
+        - Item with the specific ID already exists in the shopping cart.\n\n
+        - Item with the specific ID already exists.\n\n
       The route will respond the failed message with respect to the situation."
     content:
       application/json:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: Item with specific ID is already exist in shopping cart.
+          message: Item with the specific ID already exists in the shopping cart.
   422:
     description: The posted data has the correct format, but the data is invalid.
     content:

--- a/backend/api/shopping_cart/shopping_cart/item/put.yml
+++ b/backend/api/shopping_cart/shopping_cart/item/put.yml
@@ -51,7 +51,7 @@ responses:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: The specific ID of item is absent in shopping cart.
+          message: Item with specific ID is not exist in shopping cart.
   422:
     description: The posted data has the correct format, but the data is invalid.
     content:

--- a/backend/api/shopping_cart/shopping_cart/item/put.yml
+++ b/backend/api/shopping_cart/shopping_cart/item/put.yml
@@ -43,15 +43,15 @@ responses:
   403:
     description:
       "The possible situations that cause `403`:\n\n
-        - Item with specific ID is not exist in shopping cart. \n\n
-        - Item with specific ID is not exists. \n\n
+        - Item with the specific ID does not exist in the shopping cart.\n\n
+        - Item with the specific ID does not exist.\n\n
       The route will respond the failed message with respect to the situation."
     content:
       application/json:
         schema:
           $ref: '#/definitions/message'
         example:
-          message: Item with specific ID is not exist in shopping cart.
+          message: Item with the specific ID does not exist in the shopping cart.
   422:
     description: The posted data has the correct format, but the data is invalid.
     content:

--- a/backend/api/shopping_cart/shopping_cart/item/put.yml
+++ b/backend/api/shopping_cart/shopping_cart/item/put.yml
@@ -41,7 +41,11 @@ responses:
         example:
           message: Unauthorized.
   403:
-    description: The specific ID of item is absent in shopping cart.
+    description:
+      "The possible situations that cause `403`:\n\n
+        - Item with specific ID is not exist in shopping cart. \n\n
+        - Item with specific ID is not exists. \n\n
+      The route will respond the failed message with respect to the situation."
     content:
       application/json:
         schema:
@@ -49,13 +53,7 @@ responses:
         example:
           message: The specific ID of item is absent in shopping cart.
   422:
-    description:
-      "The possible situations that cause `422`:\n\n
-        - The ID of the payload is absent in items.\n\n
-        - The data type of ID is invalid.\n\n
-        - The count of the payload is negative.\n\n
-       The route will respond the failed message with respect to the situation.
-      "
+    description: The posted data has the correct format, but the data is invalid.
     content:
       application/json:
         schema:

--- a/backend/util.py
+++ b/backend/util.py
@@ -41,7 +41,7 @@ def route_with_doc(bp: Blueprint, rule: str, methods: list[str]):
     def wrapper(func):
         for method in methods:
             swag_from(
-                f"../api/{bp.name}{doc_path}/{method.lower()}.yml",
+                f"../../api/{bp.name}{doc_path}/{method.lower()}.yml",
                 methods=[method],
             )(func)
         return bp.route(rule, methods=methods)(func)


### PR DESCRIPTION
## What's new?

主要調整了這些部分：
 - 重新界定了 `FORBIDDEN` 與 `UNPROCESSABLE ENTITY` 的差別，
   將原先存在於 `PUT` 被判定為 `UNPROCESSABLE ENTITY` 的事物移至 `FORBIDDEN`。
   - `PUT` 必須要考慮物品是否存在於購物車，並且考慮物品是否存在，若不符合則回傳 `FORBIDDEN`。
   - `POST` 必須要考慮物品是否存在於購物車，並且考慮物品是否存在，若不符合則回傳 `FORBIDDEN`。
 - `GET` 時若無登入則回傳 `UNAUTHORIZED` 