### PR TITLE
修復 orders 的 API 文件和 route 實作分歧的部分

### DIFF
--- a/backend/api/order/orders/get.yml
+++ b/backend/api/order/orders/get.yml
@@ -50,4 +50,50 @@ definitions:
         description: The status of the delivery.
         example: PENDING
       detail:
-        $ref: '#/definitions/order_payload'
+        $ref: '#/definitions/order_payload_with_user_info'
+
+  # The "order_payload" from post can't be reused since we need some extra
+  # properties here.
+  order_payload_with_user_info:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: integer
+            count:
+              type: integer
+      date:
+        type: integer
+      note:
+        type: string
+      delivery_info:
+        type: object
+        properties:
+          firstname:
+            type: string
+          lastname:
+            type: string
+          email:
+            type: string
+          phone_number:
+            type: string
+          address:
+            type: string
+    example:
+      items:
+        - id: 3
+          count: 5
+        - id: 5
+          count: 7
+      note: "No Iansui"
+      date: 1672737308
+      delivery_info:
+        firstname: Han-Xuan
+        lastname: Huang
+        email: test@test.com
+        phone_number: 0921474836
+        address: No. 1, Sec. 3, Zhongxiao E. Rd., Da'an Dist., Taipei City 106344 , Taiwan (R.O.C.)

--- a/backend/api/order/orders/post.yml
+++ b/backend/api/order/orders/post.yml
@@ -81,12 +81,6 @@ definitions:
       delivery_info:
         type: object
         properties:
-          firstname:
-            type: string
-          lastname:
-            type: string
-          email:
-            type: string
           phone_number:
             type: string
           address:
@@ -100,9 +94,5 @@ definitions:
       note: "No Iansui"
       date: 1672737308
       delivery_info:
-        firstname: Han-Xuan
-        lastname: Huang
-        email: test@test.com
         phone_number: 0921474836
         address: No. 1, Sec. 3, Zhongxiao E. Rd., Da'an Dist., Taipei City 106344 , Taiwan (R.O.C.)
-


### PR DESCRIPTION
## What's changed?

移除 `POST /orders` 中在 `delivery_info` 內的 `firstname`、`lastname` 以及 `email`，共 3 個欄位。

因為經過討論，我們的 order 在新增（POST） 時會自動透過當前登入之使用者的身分查詢其上述欄位，不會讓使用者再次輸入，故移除。

## Details

因為這個 `order_payload` 於 *Swagger* API 中的 *definition* 是被 reuse 的，所以影響到了其他 route 中的 *definition*（`order_response`）。也因為不能只抽換部分 *properties* 的緣故，重新定義了一個和 `order_payload` 相像的 `order_payload_with_user_info` 來給其他仍需要回傳 `firstname`、`lastname` 以及 `email` 的 *definition* 使用。

## What to review?

- `/orders` 的各個 route 是否都有正常顯示
- 移除的欄位是否都有確實移除，並且沒有影響到需要保留的地方
- *definition* 的命名（`order_payload_with_user_info`）是否符合我們的慣例