### PR TITLE
Rename test classes of integration test with convention

### DIFF
--- a/backend/tests/integration_tests/test_item.py
+++ b/backend/tests/integration_tests/test_item.py
@@ -19,11 +19,11 @@ class TestGetItemsByIdRouteWithMariaDB(TestGetItemsByIdRoute):
     pass
 
 
-class TestGetItemsCountByIdRouteWithTestGetItemsRoute(TestGetItemsCountByIdRoute):
+class TestGetItemsCountByIdRouteWithMariaDB(TestGetItemsCountByIdRoute):
     pass
 
 
-class TestGetItemsRouteTestGetItemsRoute(TestGetItemsRoute):
+class TestGetItemsRouteWithMariaDB(TestGetItemsRoute):
     pass
 
 


### PR DESCRIPTION
Broken because of copy-pasting mistake.
Convention:
    The name of its corresponding unit test class + "WithMariaDB"