### PR TITLE
Fix `GET /items` to match with API documentation

### DIFF
--- a/backend/src/item/route.py
+++ b/backend/src/item/route.py
@@ -32,21 +32,24 @@ def fetch_all_items() -> Response:
     )
 
     items: list[Item] = db.session.execute(db.select(Item)).scalars().all()
-    payload: list[dict[str, Any]] = [
-        {
-            "avatar": item.avatar,
-            "count": item.count,
-            "description": item.description,
-            "id": item.id,
-            "name": item.name,
-            "price": {
-                "discount": item.discount,
-                "original": item.original,
-            },
-            "tags": item_id_to_tags.get(item.id, []),
-        }
-        for item in items
-    ]
+    payload: dict[str, Any] = {
+        "count": len(items),
+        "items": [
+            {
+                "avatar": item.avatar,
+                "count": item.count,
+                "description": item.description,
+                "id": item.id,
+                "name": item.name,
+                "price": {
+                    "discount": item.discount,
+                    "original": item.original,
+                },
+                "tags": item_id_to_tags.get(item.id, []),
+            }
+            for item in items
+        ],
+    }
     return make_response(payload)
 
 

--- a/backend/tests/unit_tests/item/test_item.py
+++ b/backend/tests/unit_tests/item/test_item.py
@@ -588,20 +588,23 @@ class TestGetItemsRoute:
             "original": 30,
             "discount": 25,
         }
-        excepted_payload: list[dict[str, Any]] = [
-            {
-                "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
-                "count": 10,
-                "description": "This is an apple.",
-                "id": 1,
-                "name": "apple",
-                "price": {
-                    "original": 30,
-                    "discount": 25,
-                },
-                "tags": [],
-            }
-        ]
+        excepted_payload: dict[str, Any] = {
+            "count": 1,
+            "items": [
+                {
+                    "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
+                    "count": 10,
+                    "description": "This is an apple.",
+                    "id": 1,
+                    "name": "apple",
+                    "price": {
+                        "original": 30,
+                        "discount": 25,
+                    },
+                    "tags": [],
+                }
+            ],
+        }
         with app.app_context():
             item = Item(**item_data)
             db.session.add(item)
@@ -616,32 +619,35 @@ class TestGetItemsRoute:
     def test_with_route_should_respond_correct_payload(
         self, client: FlaskClient, setup_item: None
     ) -> None:
-        excepted_payload: list[dict[str, Any]] = [
-            {
-                "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
-                "count": 10,
-                "description": "This is an apple.",
-                "id": 1,
-                "name": "apple",
-                "price": {
-                    "original": 30,
-                    "discount": 25,
+        excepted_payload: dict[str, Any] = {
+            "count": 2,
+            "items": [
+                {
+                    "avatar": "xx-S0m3-aVA7aR-0f-a991e-xx",
+                    "count": 10,
+                    "description": "This is an apple.",
+                    "id": 1,
+                    "name": "apple",
+                    "price": {
+                        "original": 30,
+                        "discount": 25,
+                    },
+                    "tags": [{"id": 1, "name": "fruit"}, {"id": 3, "name": "grocery"}],
                 },
-                "tags": [{"id": 1, "name": "fruit"}, {"id": 3, "name": "grocery"}],
-            },
-            {
-                "avatar": "xx-S0m3-aVA7aR-0f-ti1a9iA-xx",
-                "count": 3,
-                "description": "This is a tilapia.",
-                "id": 2,
-                "name": "tilapia",
-                "price": {
-                    "original": 50,
-                    "discount": 45,
+                {
+                    "avatar": "xx-S0m3-aVA7aR-0f-ti1a9iA-xx",
+                    "count": 3,
+                    "description": "This is a tilapia.",
+                    "id": 2,
+                    "name": "tilapia",
+                    "price": {
+                        "original": 50,
+                        "discount": 45,
+                    },
+                    "tags": [{"id": 2, "name": "fish"}, {"id": 3, "name": "grocery"}],
                 },
-                "tags": [{"id": 2, "name": "fish"}, {"id": 3, "name": "grocery"}],
-            },
-        ]
+            ],
+        }
 
         response: TestResponse = client.get("/items")
 


### PR DESCRIPTION
## What's changed?

`GET /items` 在實作時沒有符合 API 文件的定義，遺漏了 `count` 這個欄位。
此 PR 修復了上述問題，使實際介面和文件保持一致。