### PR TITLE
Fix unreasonable examples in apidocs

### DIFF
--- a/backend/api/item/items/get.yml
+++ b/backend/api/item/items/get.yml
@@ -51,6 +51,7 @@ definitions:
       count:
         description: The count of the items.
         type: integer
+        example: 1
       items:
         type: array
         description: The array contains all the items.

--- a/backend/api/tag/tags/get.yml
+++ b/backend/api/tag/tags/get.yml
@@ -17,7 +17,7 @@ definitions:
     properties:
       count:
         type: integer
-        example: 4
+        example: 1
       tags:
         type: array
         description: The array contains all the tags.


### PR DESCRIPTION
修正了 3 處在 GET 時 count 和實際 items / tags 數量不一致的問題。

> 實際上只有調整 2 處，但因為調整了 definition，有連帶影響